### PR TITLE
improves performance of the divide and conquer algorithm

### DIFF
--- a/src/algorithms/divide-and-conquer/ClosestPair.java
+++ b/src/algorithms/divide-and-conquer/ClosestPair.java
@@ -459,7 +459,7 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// next iteration.
 			pos = Rx.search(Rx, coord);
 			if (pos != 0)
-				Ry.push_back( Ry, Ly.pop(Ly, coord) );
+				Ry.push_back( Ry, Ly.pop(Ly, idx) );
 			else
 				++idx;
 		}
@@ -642,7 +642,7 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// next iteration.
 			pos = Rx.search(Rx, coord);
 			if (pos != 0)
-				Ry.push_back( Ry, Ly.pop(Ly, coord) );
+				Ry.push_back( Ry, Ly.pop(Ly, idx) );
 			else
 				++idx;
 		}
@@ -799,7 +799,7 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// calculates distance (magnitude) and prunes those
 			// too far to be closest-pair candidates
 			if (d > d_min)
-				L.pop (L, coord);
+				L.pop (L, idx);
 			--idx;
 		}
 
@@ -832,7 +832,7 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// to be closest-pair candidates
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
-				R.pop (R, coord);
+				R.pop (R, idx);
 			else
 				break;
 			--idx;

--- a/src/algorithms/divide-and-conquer/ClosestPair.java
+++ b/src/algorithms/divide-and-conquer/ClosestPair.java
@@ -786,13 +786,10 @@ class ClosestPair_DivideAndConquerAlgorithm
 		// gets the x or y-coordinate of the selected particle
 		int ax_m = middle[axis];
 
-		int idx = 0;
+		int idx = (L.size(L) - 1);
 		int size = L.size (L);
 		for (int n = 0; n != size; ++n)
 		// pops particles farther than the closest pair in `Left'
-		// NOTE: vector is sorted so no need to traverse it fully
-		//       and no need to update index since pop does that
-		//       behind scenes.
 		{
 			// gets x (y) coordinate of the referenced particle
 			coord = L.index (L, idx);
@@ -803,8 +800,7 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// too far to be closest-pair candidates
 			if (d > d_min)
 				L.pop (L, coord);
-			else
-				break;
+			--idx;
 		}
 
 
@@ -836,14 +832,10 @@ class ClosestPair_DivideAndConquerAlgorithm
 			// to be closest-pair candidates
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
-			{
 				R.pop (R, coord);
-				// decrements index to consider the next
-				// from back to front of the vector
-				--idx;
-			}
 			else
 				break;
+			--idx;
 		}
 
 		// returns the closest pair in the boundary if there is any

--- a/src/algorithms/divide-and-conquer/Vector.java
+++ b/src/algorithms/divide-and-conquer/Vector.java
@@ -260,6 +260,19 @@ public class Vector
 	}
 
 
+	public static int [] pop (Vector vector, int idx)
+	// pops vector element by index
+	{
+		String errmsg = ("pop(): out-of-bounds error");
+		if (idx < vector.begin || idx >= vector.avail)
+			throw new RuntimeException (errmsg);
+
+		int pos = (idx + 1);
+		Coord coord = popit (vector, pos);
+		return coord.toArray(coord);
+	}
+
+
 	public static int [] pop (Vector vector, int [] coords)
 	// pops selected coordinates from vector
 	{

--- a/src/algorithms/divide-and-conquer/recursiveClosestPair.java
+++ b/src/algorithms/divide-and-conquer/recursiveClosestPair.java
@@ -225,7 +225,7 @@ class recursiveClosestPair
 			// next iteration.
 			pos = Rx.search(Rx, coord);
 			if (pos != 0)
-				Ry.push_back( Ry, Ly.pop(Ly, coord) );
+				Ry.push_back( Ry, Ly.pop(Ly, idx) );
 			else
 				++idx;
 		}
@@ -430,7 +430,7 @@ class recursiveClosestPair
 
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
-				L.pop (L, coord);
+				L.pop (L, idx);
 			--idx;
 		}
 
@@ -462,7 +462,7 @@ class recursiveClosestPair
 
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
-				R.pop (R, coord);
+				R.pop (R, idx);
 			else
 				break;
 			--idx;

--- a/src/algorithms/divide-and-conquer/recursiveClosestPair.java
+++ b/src/algorithms/divide-and-conquer/recursiveClosestPair.java
@@ -205,30 +205,29 @@ class recursiveClosestPair
 		Vector Ry = new Vector();	// placeholder for Ry
 
 		int pos;			// positional index
-		int idx = 0;			// element index
 		int size = Ly.size (Ly);	// number of elements
 		int [] coord = new int [2];	// coordinate placeholder
-		// pops elements in Py matching Rx while inserting into Ry
-		// to obtain both Ly and Ry subsets
-		for (int n = 0; n != size; ++n)
-		// NOTE: pops elements in Py in order (beginning to end)
-		//       so that Ry ends up with the same ordering of Py
+		for (int idx = 0; idx != size; ++idx)
+		// copies elements in Py in order (beginning to end)
+		// so that Ry ends up with the same ordering of Py
 		{
 			coord = Ly.index(Ly, idx);
-			// Note that when popping elements from beginning
-			// to end it is not necessary to increment the
-			// index when an element is popped because the next
-			// element in the vector ends up in the popped
-			// location. On the other hand, if the current
-			// element is not popped, the index needs to be
-			// incremented to consider the next element on the
-			// next iteration.
 			pos = Rx.search(Rx, coord);
 			if (pos != 0)
-				Ry.push_back( Ry, Ly.pop(Ly, idx) );
-			else
-				++idx;
+				Ry.push_back( Ry, coord );
 		}
+
+		int idx;
+		for (int i = 0; i != size; ++i)
+		// pops elements present in Rx from Ly from back to front
+		{
+			idx = size - (i + 1);
+			coord = Ly.index(Ly, idx);
+			pos = Rx.search(Rx, coord);
+			if (pos != 0)
+				Ly.pop (Ly, idx);
+		}
+
 
 		// fits vectors to size to reduce memory usage
 		Ly.fit(Ly);

--- a/src/algorithms/divide-and-conquer/recursiveClosestPair.java
+++ b/src/algorithms/divide-and-conquer/recursiveClosestPair.java
@@ -413,18 +413,17 @@ class recursiveClosestPair
 
 		int [] coord;
 		// gets coordinates of the particle closest to boundary
-		// NOTE: The first particle in the upper quadrant is closer
+		// NOTE: The first particle in the Right (upper) subset
+		//       is closer
 		int [] middle = R.index (R, 0);
 		// gets the x or y-coordinate of the selected particle
 		int ax_m = middle[axis];
 
-		int idx = 0;
+		int idx = (L.size (L) - 1);
 		int size = L.size (L);
 		for (int n = 0; n != size; ++n)
 		// pops particles farther than the closest pair in `Left'
-		// NOTE: vector is sorted so no need to traverse it fully
-		//       and no need to update index since pop does that
-		//       behind scenes.
+		// NOTE: Removes elements from the back for speed.
 		{
 			coord = L.index (L, idx);
 			ax = coord[axis];
@@ -432,8 +431,7 @@ class recursiveClosestPair
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
 				L.pop (L, coord);
-			else
-				break;
+			--idx;
 		}
 
 
@@ -464,12 +462,10 @@ class recursiveClosestPair
 
 			d = (ax > ax_m)? (ax - ax_m): (ax_m - ax);
 			if (d > d_min)
-			{
 				R.pop (R, coord);
-				--idx;
-			}
 			else
 				break;
+			--idx;
 		}
 
 		if ( L.size(L) != 0 && R.size(R) != 0 )


### PR DESCRIPTION
closes #63 

Most changes involve the removal of elements from the back of the vector to decrease the overhead that pop does behind scenes.

Popping by index is implemented to speed up the construction of subsets as well.

Division of half subsets into quadrants has also been improved by separating the construction of the lower and upper quadrants. Doing it simultaneously incurs in large overhead because elements have to be removed from the front to the back of the vector to preserve the ordered structure of y-x sorted datasets.
