### PR TITLE
updates time-complexity plot [python]

### DIFF
--- a/src/containers/vector/particles/java/loglogPlot.py
+++ b/src/containers/vector/particles/java/loglogPlot.py
@@ -48,7 +48,7 @@ c2 = size.mean() / opers.mean()
 ax.loglog(size, size,    color='black', linestyle='--',
           label='linear')
 # plots the elapsed time as a function of size
-ax.loglog(size[5:], c1 * etime[5:], color='black',
+ax.loglog(size, c1 * etime, color='black',
     linestyle='', marker='o', markersize=12, label='elapsed-time')
 # plots the number of operations as a function of size
 ax.loglog(size, c2 * opers, color='red',   linestyle='', marker='*',


### PR DESCRIPTION
COMMENTS:
Plots the full range of the elapsed-time data.

This is the version used to generate the plot for the presentation of the closest-pair problem.

Both the elapsed time and the number of distance computations exhibit a linear dependence with the input size.

The time-complexity study was repeated because the HPCf node executing the code was running with more jobs that it should handle.