### PR TITLE
fixes possible integer arithmetic overflow [Java]

### DIFF
--- a/src/iterators/vector/particles/java/Ensemble.java
+++ b/src/iterators/vector/particles/java/Ensemble.java
@@ -1564,7 +1564,8 @@ public class Ensemble	// Particle Ensemble Class
 
 
 		// defines limits for the point coordinates along the axes
-		double limit = (this.size * this.size);
+		double size = this.size;
+		double limit = (size * size);
 		double x_min = -limit, x_max = limit;
 		double y_min = -4, y_max = 4;
 
@@ -1624,7 +1625,8 @@ public class Ensemble	// Particle Ensemble Class
 
 
 		// defines limits for the point coordinates along the axes
-		double limit = (this.size * this.size);
+		double size = this.size;
+		double limit = (size * size);
 		double x_min = -limit, x_max = limit;
 		double y_min = -limit, y_max = limit;
 
@@ -1684,7 +1686,8 @@ public class Ensemble	// Particle Ensemble Class
 
 
 		// defines limits for the point coordinates along the axes
-		double limit = (this.size * this.size);
+		double size = this.size;
+		double limit = (size * size);
 		double x_min = -limit, x_max = limit;
 		double y_min = -limit, y_max = limit;
 		double z_min = -limit, z_max = limit;

--- a/src/iterators/vector/particles/java/Ensemble.java
+++ b/src/iterators/vector/particles/java/Ensemble.java
@@ -1545,7 +1545,7 @@ public class Ensemble	// Particle Ensemble Class
 	utility.
 
 	Inputs:
-	None		size of the dataset (number of particles)
+	None
 
 	Output:
 	points		a vector that stores the dataset of points


### PR DESCRIPTION
The possible overflow could happen for larger ensembles. Java could typecast the ensemble size from int to double before computing the product but I rather not take any chances.

Removes input description from older revision in the create method, which takes no parameters.