### PR TITLE
removes object (de)construction overhead [FORTRAN]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/EnsembleClass.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/EnsembleClass.for
@@ -47,18 +47,25 @@ public :: Ensemble_tests
             procedure, public :: bruteForceArrayBased
             ! Divide And Conquer Methods
             procedure, public :: recursive1D
+            procedure, public :: recursive1D2           ! (version 2)
             ! setters (or timers)
             procedure :: bruteForceMethod
             procedure :: bruteForceMethodArrayBased
             procedure :: recursive1DMethod
+            procedure :: recursive1DMethod2             ! (version 2)
             ! implements recursive algorithms
             procedure :: recurse
+            procedure :: recurse2                       ! (version 2)
             procedure :: combine
+            procedure :: combine2                       ! (version 2)
             ! implements distance computing algorithms
             procedure :: distanceOOP
             procedure :: distanceArrayBased
+            procedure :: distanceArrayBased2            ! (version 2)
             procedure :: distanceSmallerPartition
+            procedure :: distanceSmallerPartition2
             procedure :: distancePartitionInterface
+            procedure :: distancePartitionInterface2
             ! utilities
             procedure :: toArray
             procedure :: isInvalidData
@@ -68,8 +75,9 @@ public :: Ensemble_tests
             procedure :: create2D
             procedure :: export
             ! generics
-            generic :: distance => distanceOOP, distanceArrayBased,&
-                                  &distanceSmallerPartition, distancePartitionInterface
+            generic :: distance => distanceOOP, distanceArrayBased, distanceArrayBased2,&
+                                  &distanceSmallerPartition, distanceSmallerPartition2,&
+                                  &distancePartitionInterface, distancePartitionInterface2
     end type
 
 
@@ -139,6 +147,11 @@ public :: Ensemble_tests
             class(Ensemble), intent(inout) :: this
         end subroutine
 
+        module subroutine recursive1D2 (this)
+        ! applies the 1D Divide And Algorithm to find the closest pair (version 2)
+            class(Ensemble), intent(inout) :: this
+        end subroutine
+
     end interface
 
 
@@ -169,11 +182,28 @@ public :: Ensemble_tests
         end subroutine
 
 
+        module subroutine recursive1DMethod2 (this)
+        ! as recursive1DMethod() but does not (de)constructs derived-type objects (ver 2)
+            class(Ensemble), intent(inout) :: this
+        end subroutine
+
+
         module recursive function recurse (this, beginPosition, endPosition, Px) result(t)
         ! implements the 1D Divide And Conquer Algorithm that finds the closest pair
             class(Ensemble), intent(in) :: this
             type(Tuple), pointer :: t
             real(kind = real64), intent(in) :: Px(:, :)
+            integer(kind = int32), intent(in) :: beginPosition
+            integer(kind = int32), intent(in) :: endPosition
+        end function
+
+
+        module recursive function recurse2 (this, beginPosition, endPosition, Px)&
+                                           &result(ret)
+        ! implements the 1D Divide And Conquer Algorithm that finds the closest pair ver 2
+            class(Ensemble), intent(in) :: this
+            real(kind = real64) :: ret(3)
+            real(kind = real64), intent(in) :: Px(this % size, 2)
             integer(kind = int32), intent(in) :: beginPosition
             integer(kind = int32), intent(in) :: endPosition
         end function
@@ -186,6 +216,18 @@ public :: Ensemble_tests
             type(Tuple), pointer :: t
             type(Pair), intent(in) :: currentClosestPair
             real(kind = real64), intent(in) :: Px(:, :)
+            integer(kind = int32), intent(in) :: beginPosition
+            integer(kind = int32), intent(in) :: endPosition
+        end function
+
+
+        module function combine2 (this, beginPosition, endPosition,&
+                                 &Px, currentClosestPair) result(ret)
+        ! implements the combination step of the 1D Divide And Conquer Algorithm, ver 2
+            class(Ensemble), intent(in) :: this
+            real(kind = real64) :: ret(3)
+            real(kind = real64), intent(in) :: Px(this % size, 2)
+            integer(kind = int32), intent(in) :: currentClosestPair(2)
             integer(kind = int32), intent(in) :: beginPosition
             integer(kind = int32), intent(in) :: endPosition
         end function
@@ -208,6 +250,16 @@ public :: Ensemble_tests
         end function
 
 
+        module function distanceArrayBased2 (this, points, closestPair)&
+                                            &result(ret)
+        ! FORTRAN77 (or procedural) implementation of the Brute Force Algorithm, version 2
+            class(Ensemble), intent(in) :: this
+            real(kind = real64) :: ret(3)
+            real(kind = real64), intent(in) :: points(this % size, 2)
+            integer(kind = int32), intent(out) :: closestPair(2)
+        end function
+
+
         module function distanceSmallerPartition (this, beginPosition, endPosition, Px)&
                                                  &result(t)
         ! implements the Brute Force Algorithm for smaller partitions
@@ -219,6 +271,18 @@ public :: Ensemble_tests
         end function
 
 
+        module function distanceSmallerPartition2 (this, beginPosition, endPosition, Px,&
+                                                  &closestPair) result(ret)
+        ! implements the Brute Force Algorithm for smaller partitions (version 2)
+            class(Ensemble), intent(in) :: this
+            real(kind = real64) :: ret(3)
+            real(kind = real64), intent(in) :: Px(this % size, 2)
+            integer(kind = int32), intent(in) :: beginPosition
+            integer(kind = int32), intent(in) :: endPosition
+            integer(kind = int32), intent(out) :: closestPair(2)
+        end function
+
+
         module function distancePartitionInterface (this, beginPosLeft, endPosLeft,&
                                                    &beginPosRight, endPosRight, Px,&
                                                    &currentClosestPair) result(t)
@@ -227,6 +291,19 @@ public :: Ensemble_tests
             type(Tuple), pointer :: t
             type(Pair), intent(in) :: currentClosestPair
             real(kind = real64), intent(in) :: Px(:, :)
+            integer(kind = int32), intent(in) :: beginPosLeft, endPosLeft
+            integer(kind = int32), intent(in) :: beginPosRight, endPosRight
+        end function
+
+
+        module function distancePartitionInterface2 (this, beginPosLeft, endPosLeft,&
+                                                    &beginPosRight, endPosRight, Px,&
+                                                    &currentClosestPair) result(ret)
+        ! implements the partition interface, closest-pair, finding method (version 2)
+            class(Ensemble), intent(in) :: this
+            real(kind = real64) :: ret(3)
+            real(kind = real64), intent(in) :: Px(this % size, 2)
+            integer(kind = int32), intent(in) :: currentClosestPair(2)
             integer(kind = int32), intent(in) :: beginPosLeft, endPosLeft
             integer(kind = int32), intent(in) :: beginPosRight, endPosRight
         end function

--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/TimeComplexityClass.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/TimeComplexityClass.for
@@ -32,9 +32,11 @@ save
             procedure :: timeBruteForce
             procedure :: timeBruteForceArrayBased
             procedure :: timeDivideAndConquer1D
+            procedure :: timeDivideAndConquer1D2                           ! version 2
             procedure, public :: exportTimeComplexity_BruteForce
             procedure, public :: exportTimeComplexity_BruteForceArrayBased
             procedure, public :: exportTimeComplexity_DivideAndConquer1D
+            procedure, public :: exportTimeComplexity_DivideAndConquer1D2  ! version 2
     end type
 
 
@@ -86,6 +88,12 @@ save
             class(TimeComplexity), intent(in) :: this
         end subroutine
 
+        module subroutine exportTimeComplexity_DivideAndConquer1D2 (this) ! (version 2)
+        ! exports the time complexity results of the implementation of the 1D Divide And
+        ! Conquer Algorithm
+            class(TimeComplexity), intent(in) :: this
+        end subroutine
+
     end interface
 
 
@@ -116,6 +124,15 @@ save
         module subroutine timeDivideAndConquer1D (this, sizes, avgElapsedTimes,&
                                                  &avgNumOperations)
         ! times the implementation of the 1D Divide And Conquer Algorithm
+            class(TimeComplexity), intent(in) :: this
+            real(kind = real64), allocatable, intent(out) :: sizes(:)
+            real(kind = real64), allocatable, intent(out) :: avgElapsedTimes(:)
+            real(kind = real64), allocatable, intent(out) :: avgNumOperations(:)
+        end subroutine
+
+        module subroutine timeDivideAndConquer1D2 (this, sizes, avgElapsedTimes,&
+                                                 &avgNumOperations)
+        ! times the implementation of the 1D Divide And Conquer Algorithm (version 2)
             class(TimeComplexity), intent(in) :: this
             real(kind = real64), allocatable, intent(out) :: sizes(:)
             real(kind = real64), allocatable, intent(out) :: avgElapsedTimes(:)

--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/main.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/main.for
@@ -30,6 +30,7 @@ program main
 
     t = TimeComplexity(RUNS)
     ! exports the time complexity results of the 1D Divide And Conquer Algorithm
-    call t % exportTimeComplexity_DivideAndConquer1D()
+!   call t % exportTimeComplexity_DivideAndConquer1D()
+    call t % exportTimeComplexity_DivideAndConquer1D2() ! (version 2)
 
 end program

--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/methodsTimeComplexityClass.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/methodsTimeComplexityClass.for
@@ -182,6 +182,54 @@ contains
     end subroutine exportTimeComplexity_DivideAndConquer1D
 
 
+    module subroutine exportTimeComplexity_DivideAndConquer1D2 (this) ! (version 2)
+!
+!   Synopsis:
+!   Exports the time complexity results of the 1D Divide and Conquer
+!   Algorithm that solves the closest pair problem to a plain text
+!   data file.
+!
+!   Inputs:
+!   this                the time complexity object
+!
+!   Outputs:
+!   None
+!
+        class(TimeComplexity), intent(in) :: this
+        real(kind = real64), allocatable :: sizes(:)
+        real(kind = real64), allocatable :: avgElapsedTimes(:)
+        real(kind = real64), allocatable :: avgNumOperations(:)
+        integer(kind = int32) :: fhandle
+        integer(kind = int32) :: iostate
+        integer(kind = int32) :: i
+        ! exports the time complexity results in a different data file (version 2)
+        character(*), parameter :: fileDivideAndConquer = 'timeDivideAndConquer1D2.dat'
+
+        if (this % runs <= 0) then
+            return
+        endif
+
+        ! invokes the timer method (version 2)
+        call this % timeDivideAndConquer1D2(sizes, avgElapsedTimes, avgNumOperations)
+
+        open(newunit=fhandle, file=fileDivideAndConquer, action='write',&
+           & position='rewind', iostat=iostate)
+
+        if (iostate /= 0) then
+            print *, 'TimeComplexity::exportTimeComplexity_BruteForce(): IO ERROR'
+            stop
+        endif
+
+        do i = 1, this % runs
+            write (fhandle, '(3E25.15)') sizes(i), avgElapsedTimes(i), avgNumOperations(i)
+        end do
+
+        close(fhandle)
+
+        return
+    end subroutine exportTimeComplexity_DivideAndConquer1D2
+
+
     module subroutine timeBruteForce (this, sizes, avgElapsedTimes, avgNumOperations)
 !
 !   Synopsis:
@@ -356,5 +404,65 @@ contains
 
         return
     end subroutine timeDivideAndConquer1D
+
+
+    module subroutine timeDivideAndConquer1D2 (this, sizes, avgElapsedTimes,& ! (ver 2)
+                                              &avgNumOperations)
+!
+!   Synopsis:
+!   Times the Object-Oriented implementation of the 1D Divide And Conquer Algorithm that
+!   solves the closest pair problem. The method returns the ensemble sizes considered,
+!   and the average elapsed-time and number of operations executed by the implementation
+!   to solve the closest pair problem.
+!
+!   Inputs:
+!   this                the time complexity object
+!
+!   Outputs:
+!   sizes               first-rank array of ensemble sizes
+!   avgElapsedTimes     first-rank array storing the average elapsed-times
+!   avgNumOperations    first-rank array storing the average number of operations
+!
+        class(TimeComplexity), intent(in) :: this
+        type(Ensemble) :: ens
+        real(kind = real64), allocatable, intent(out) :: sizes(:)
+        real(kind = real64), allocatable, intent(out) :: avgElapsedTimes(:)
+        real(kind = real64), allocatable, intent(out) :: avgNumOperations(:)
+        real(kind = real64) :: elapsedTime
+        real(kind = real64) :: numOperations
+        integer(kind = int32) :: ensembleSize
+        integer(kind = int32) :: runs, reps
+        integer(kind = int32) :: run, rep
+        integer(kind = int32) :: mstat
+
+        runs = this % runs
+        allocate(sizes(runs), avgElapsedTimes(runs), avgNumOperations(runs), stat=mstat)
+
+        if (mstat /= 0) then
+            print *, 'TimeComplexity::timeDivideAndConquer1D(): failed to allocate arrays'
+            stop
+        end if
+
+        reps = 256
+        ensembleSize = 16
+        do run = 1, runs
+            elapsedTime = 0.0_real64
+            numOperations = 0.0_real64
+            do rep = 1, reps
+                ens = Ensemble(ensembleSize)
+                ! invokes the recursive1D() method (version 2)
+                call ens % recursive1D2()
+                elapsedTime = elapsedTime + ens % getElapsedTime()
+                numOperations = numOperations + ens % getNumOperations()
+            end do
+            sizes(run) = real(ensembleSize, kind=real64)
+            avgElapsedTimes(run) = elapsedTime / real(reps, kind=real64)
+            avgNumOperations(run) = numOperations / real(reps, kind=real64)
+
+            ensembleSize = 2 * ensembleSize
+        end do
+
+        return
+    end subroutine timeDivideAndConquer1D2
 
 end submodule


### PR DESCRIPTION
COMMENTS:
Removes object (de)construction overhead from the implementation of the 1D Divide And Conquer Algorithm that solves the closest pair problem.

As a result of this, the implementation in FORTRAN is at least 1.5 times faster than the implementation in Java and at least 2 times faster than the implementation in C++ (for ensembles of size 2048). Confirming that the overhead of (de)constructing objects dynamically was significant, as noted in the previous commit.

For academic reasons both versions of Divide And Conquer Algorithm have been kept.

Nevertheless, the overall runtime of the application in FORTRAN has not changed significantly, for the sorting algorithm (which runs on quadratic time) determines the overall application runtime:

[@hostname fortran]$ time ./test-closest-pair

real	0m53.971s
user	0m53.871s
sys	0m0.044s

Valgrind reports that memory leaks are not possible.