### PR TITLE
bruteForceMethod -> timeBruteForce for readability

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/cxx/EnsembleClass.cpp
+++ b/src/algorithms/divide-and-conquer/closest-pair/cxx/EnsembleClass.cpp
@@ -94,7 +94,7 @@ None
 	this -> createDataset1D(points);
 
 	// uses the brute force algorithm to find the closest pair
-	Pair *closestPair = this -> bruteForceMethod(points);
+	Pair *closestPair = this -> timeBruteForce(points);
 	handler.add(closestPair);
 
 	// displays info about the closest pair on the console
@@ -138,12 +138,12 @@ None
 
 
 	// saves the closest pair found by the Brute Force Algorithm
-	Pair *closestPairBruteForce = this -> bruteForceMethod(points);
+	Pair *closestPairBruteForce = this -> timeBruteForce(points);
 	handler.add(closestPairBruteForce);
 
 
 	// uses the 1D Divide And Conquer Algorithm to find the closest pair
-	Pair *closestPair = this -> recursive1DMethod(points);
+	Pair *closestPair = this -> timeRecursive1D(points);
 	handler.add(closestPair);
 
 
@@ -169,7 +169,7 @@ None
 /* implementations */
 
 
-Pair* Ensemble::bruteForceMethod (std::vector<Point*>& points)
+Pair* Ensemble::timeBruteForce (std::vector<Point*>& points)
 /*
 
 Synopsis:
@@ -229,7 +229,7 @@ closestPair	the closest pair
 }
 
 
-Pair* Ensemble::recursive1DMethod (std::vector<Point*>& points)
+Pair* Ensemble::timeRecursive1D (std::vector<Point*>& points)
 /*
 
 Synopsis:

--- a/src/algorithms/divide-and-conquer/closest-pair/cxx/EnsembleClass.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/cxx/EnsembleClass.h
@@ -94,10 +94,10 @@ class Ensemble	// Ensemble of Points Class
 
 
 	// times the Brute Force Algorithm
-	Pair* bruteForceMethod (std::vector<Point*>& points);
+	Pair* timeBruteForce (std::vector<Point*>& points);
 
 	// times the 1D Divide And Conquer Algorithm
-	Pair* recursive1DMethod (std::vector<Point*>& points);
+	Pair* timeRecursive1D (std::vector<Point*>& points);
 
 	// implements the 1D Divide And Conquer Algorithm
 	std::tuple<Pair*, double> recurse (const std::vector<Point*>& Px) const;

--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/EnsembleClass.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/EnsembleClass.for
@@ -49,10 +49,10 @@ public :: Ensemble_tests
             procedure, public :: recursive1D
             procedure, public :: recursive1D2           ! (version 2)
             ! setters (or timers)
-            procedure :: bruteForceMethod
-            procedure :: bruteForceMethodArrayBased
-            procedure :: recursive1DMethod
-            procedure :: recursive1DMethod2             ! (version 2)
+            procedure :: timeBruteForce
+            procedure :: timeBruteForceArrayBased
+            procedure :: timeRecursive1D
+            procedure :: timeRecursive1D2               ! (version 2)
             ! implements recursive algorithms
             procedure :: recurse
             procedure :: recurse2                       ! (version 2)
@@ -160,21 +160,21 @@ public :: Ensemble_tests
 
     interface
 
-        module subroutine bruteForceMethod (this)
+        module subroutine timeBruteForce (this)
         ! invokes the Brute Force Algorithm and sets (as a side-effect) the elapsed-time
         ! and the number of operations executed by the algorithm to find the closest pair
             class(Ensemble), intent(inout) :: this
         end subroutine
 
 
-        module subroutine bruteForceMethodArrayBased (this)
+        module subroutine timeBruteForceArrayBased (this)
         ! invokes the Brute Force Algorithm and sets (as a side-effect) the elapsed-time
         ! and the number of operations executed by the algorithm to find the closest pair
             class(Ensemble), intent(inout) :: this
         end subroutine
 
 
-        module subroutine recursive1DMethod (this)
+        module subroutine timeRecursive1D (this)
         ! invokes the 1D Divide And Conquer Algorithm and sets (as a side-effect) the
         ! elapsed-time and the number of operations executed by the algorithm to find
         ! the closest pair
@@ -182,8 +182,8 @@ public :: Ensemble_tests
         end subroutine
 
 
-        module subroutine recursive1DMethod2 (this)
-        ! as recursive1DMethod() but does not (de)constructs derived-type objects (ver 2)
+        module subroutine timeRecursive1D2 (this)
+        ! as recursive1D() but does not (de)constructs derived-type objects (ver 2)
             class(Ensemble), intent(inout) :: this
         end subroutine
 

--- a/src/algorithms/divide-and-conquer/closest-pair/fortran/methodsEnsembleClass.for
+++ b/src/algorithms/divide-and-conquer/closest-pair/fortran/methodsEnsembleClass.for
@@ -80,7 +80,7 @@ contains
 
         ! caters invalid ensemble sizes
         if (this % size >= 2) then
-            call this % bruteForceMethod()
+            call this % timeBruteForce()
         endif
 
         return
@@ -93,7 +93,7 @@ contains
 
         ! caters invalid ensemble sizes
         if (this % size >= 2) then
-            call this % bruteForceMethodArrayBased()
+            call this % timeBruteForceArrayBased()
         endif
 
         return
@@ -106,7 +106,7 @@ contains
 
         ! caters invalid ensemble sizes
         if (this % size >= 2) then
-            call this % recursive1DMethod()
+            call this % timeRecursive1D()
         endif
 
         return
@@ -119,14 +119,14 @@ contains
 
         ! caters invalid ensemble sizes
         if (this % size >= 2) then
-            call this % recursive1DMethod2()
+            call this % timeRecursive1D2()
         endif
 
         return
     end subroutine
 
 
-    module subroutine bruteForceMethod (this)
+    module subroutine timeBruteForce (this)
 !
 !   Synopsis:
 !   Times the Object Oriented implementation of the Brute Force Algorithm.
@@ -189,10 +189,10 @@ contains
         closestPair => null()
 
         return
-    end subroutine bruteForceMethod
+    end subroutine timeBruteForce
 
 
-    module subroutine recursive1DMethod (this)
+    module subroutine timeRecursive1D (this)
 !
 !   Synopsis:
 !   Times the implementation of the 1D Divide And Conquer Algorithm.
@@ -291,10 +291,10 @@ contains
         t => null()
 
         return
-    end subroutine recursive1DMethod
+    end subroutine timeRecursive1D
 
 
-    module subroutine recursive1DMethod2 (this)
+    module subroutine timeRecursive1D2 (this)
 !
 !   Synopsis:
 !   Times the implementation of the (version 2) 1D Divide And Conquer Algorithm.
@@ -421,10 +421,10 @@ contains
         deallocate(points, Px)
 
         return
-    end subroutine recursive1DMethod2
+    end subroutine timeRecursive1D2
 
 
-    module subroutine bruteForceMethodArrayBased (this)
+    module subroutine timeBruteForceArrayBased (this)
     ! times the FORTRAN77 (procedural) implementation of the Brute Force Algorithm
         class(Ensemble), intent(inout) :: this
         class(Point), allocatable :: dataset(:)
@@ -476,7 +476,7 @@ contains
         closestPair => null()
 
         return
-    end subroutine bruteForceMethodArrayBased
+    end subroutine timeBruteForceArrayBased
 
 
     module recursive function recurse (this, beginPosition, endPosition, Px) result(t)

--- a/src/iterators/list/singly-linked-list/particles/java/Ensemble.java
+++ b/src/iterators/list/singly-linked-list/particles/java/Ensemble.java
@@ -131,10 +131,10 @@ public class Ensemble	// Particle Ensemble Class
 		// creates a new dataset of distinct points
 		List<Point> points = this.createDataset1D();
 		// saves the closest pair found by the recursive algorithm
-		Pair closestPairRecursive = this.recursive1DMethod(points);
+		Pair closestPairRecursive = this.timeRecursive1D(points);
 
 		// uses the brute force algorithm to find the closest pair
-		Pair closestPair = this.bruteForceMethod(points);
+		Pair closestPair = this.timeBruteForce(points);
 
 		if ( !closestPair.equalTo(closestPairRecursive) )
 		// complains if the closest pairs are different
@@ -164,10 +164,10 @@ public class Ensemble	// Particle Ensemble Class
 		// creates a new dataset of distinct points
 		List<Point> points = this.createDataset1D();
 		// saves the closest pair found by the brute force method
-		Pair closestPairBruteForce = this.bruteForceMethod(points);
+		Pair closestPairBruteForce = this.timeBruteForce(points);
 
 		// finds the closest pair via divide and conquer algorithm
-		Pair closestPair = this.recursive1DMethod(points);
+		Pair closestPair = this.timeRecursive1D(points);
 
 		if ( !closestPair.equalTo(closestPairBruteForce) )
 		// complains if the closest pairs are different
@@ -229,7 +229,7 @@ public class Ensemble	// Particle Ensemble Class
 	/* implementations */
 
 
-	private Pair bruteForceMethod (List<Point> points)
+	private Pair timeBruteForce (List<Point> points)
 	/*
 
 	Synopsis:
@@ -265,7 +265,7 @@ public class Ensemble	// Particle Ensemble Class
 	}
 
 
-	private Pair recursive1DMethod (List<Point> points)
+	private Pair timeRecursive1D (List<Point> points)
 	/*
 
 	Synopsis:

--- a/src/iterators/vector/particles/java/Ensemble.java
+++ b/src/iterators/vector/particles/java/Ensemble.java
@@ -131,10 +131,10 @@ public class Ensemble	// Particle Ensemble Class
 		// creates a new dataset of distinct points
 		Vector<Point> points = this.createDataset1D();
 		// saves the closest pair found by the recursive algorithm
-		Pair closestPairRecursive = this.recursive1DMethod(points);
+		Pair closestPairRecursive = this.timeRecursive1D(points);
 
 		// uses the brute force algorithm to find the closest pair
-		Pair closestPair = this.bruteForceMethod(points);
+		Pair closestPair = this.timeBruteForce(points);
 
 		if ( !closestPair.equalTo(closestPairRecursive) )
 		// complains if the closest pairs are different
@@ -164,10 +164,10 @@ public class Ensemble	// Particle Ensemble Class
 		// creates a new dataset of distinct points
 		Vector<Point> points = this.createDataset1D();
 		// saves the closest pair found by the brute force method
-		Pair closestPairBruteForce = this.bruteForceMethod(points);
+		Pair closestPairBruteForce = this.timeBruteForce(points);
 
 		// finds the closest pair via divide and conquer algorithm
-		Pair closestPair = this.recursive1DMethod(points);
+		Pair closestPair = this.timeRecursive1D(points);
 
 		if ( !closestPair.equalTo(closestPairBruteForce) )
 		// complains if the closest pairs are different
@@ -201,10 +201,10 @@ public class Ensemble	// Particle Ensemble Class
 		Py.sort( new Point.Comparator() );
 
 		// saves the closest pair found by the brute force method
-		Pair closestPairBruteForce = this.bruteForceMethod(Px);
+		Pair closestPairBruteForce = this.timeBruteForce(Px);
 
 		// finds the closest pair via divide and conquer algorithm
-		Pair closestPair = this.recursive2DMethod(Px, Py);
+		Pair closestPair = this.timeRecursive2D(Px, Py);
 
 		if ( !closestPair.equalTo(closestPairBruteForce) )
 		// complains if the closest pairs are different
@@ -247,7 +247,7 @@ public class Ensemble	// Particle Ensemble Class
 		Pair closestPairBruteForce = dataBruteForce.getClosestPair();
 
 		// finds the closest pair via divide and conquer algorithm
-		Pair closestPair = this.recursive3DMethod(Px, Py, Pz);
+		Pair closestPair = this.timeRecursive3D(Px, Py, Pz);
 
 		if ( !closestPair.equalTo(closestPairBruteForce) )
 		// complains if the closest pairs are different
@@ -313,7 +313,7 @@ public class Ensemble	// Particle Ensemble Class
 	/* implementations */
 
 
-	private Pair bruteForceMethod (Vector<Point> points)
+	private Pair timeBruteForce (Vector<Point> points)
 	/*
 
 	Synopsis:
@@ -349,7 +349,7 @@ public class Ensemble	// Particle Ensemble Class
 	}
 
 
-	private Pair recursive1DMethod (Vector<Point> points)
+	private Pair timeRecursive1D (Vector<Point> points)
 	/*
 
 	Synopsis:
@@ -386,7 +386,7 @@ public class Ensemble	// Particle Ensemble Class
 	}
 
 
-	private Pair recursive2DMethod (Vector<Point> Px, Vector<Point> Py)
+	private Pair timeRecursive2D (Vector<Point> Px, Vector<Point> Py)
 	/*
 
 	Synopsis:
@@ -424,7 +424,7 @@ public class Ensemble	// Particle Ensemble Class
 	}
 
 
-	private Pair recursive3DMethod (
+	private Pair timeRecursive3D (
 		Vector<Point> Px, Vector<Point> Py, Vector<Point> Pz
 	)
 	/*


### PR DESCRIPTION
COMMENTS:
Removes the string `Method' from the name of `Method' ending methods, functions, subroutines, etc.

These methods are used for timing the implementation of the Brute Force Algorithm and for this reason the string `time' has been added at the front of their names to make them easier to read.

Simirly, other methods used for the same purpose have been renamed accordingly.

This applies to the implementation of the closest pair finding algorithms in Java, C++, and FORTRAN.