### PR TITLE
adds insertion sort [clang]

### DIFF
--- a/src/algorithms/sort/clang/Makefile
+++ b/src/algorithms/sort/clang/Makefile
@@ -18,7 +18,7 @@ include make-inc
 all: $(TESTS)
 
 $(TEST_BIN): $(OBJECTS)
-	$(CC) $(CCOPT) $(OBJECTS) -o $(TEST_BIN)
+	$(CC) $(CCOPT) $(OBJECTS) -o $(TEST_BIN) $(LIBS)
 
 $(TEST_OBJ): $(TEST_SRC)
 	$(CC) $(CCOPT) -c $(TEST_SRC) -o $(TEST_OBJ)

--- a/src/algorithms/sort/clang/make-inc
+++ b/src/algorithms/sort/clang/make-inc
@@ -17,9 +17,12 @@
 CC = gcc
 
 # options
-CCOPT = -mavx2 -O2 -ftree-vectorize -fopt-info-missed=missed-opts.log
 CCOPT = -mavx2 -O2 -ftree-vectorize -fopt-info-optimized=opts.log
+CCOPT = -mavx2 -O2 -ftree-vectorize -fopt-info-missed=missed-opts.log
 CCOPT = -g -Wall -Wextra -O0
+
+# libraries
+LIBS = -lm
 
 # sources
 TEST_SRC = test.c


### PR DESCRIPTION
COMMENTS:
This version of insertion sort isort() uses binary search to do a quick look up for the insertion location.

gcc can vectorize the innermost loop of the isort() (have checked with AVX capable CPU)

valgrind reports no memory issues