### PR TITLE
improves interface closest-pair [clang]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/particle.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/particle.h
@@ -1,0 +1,38 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_2D_PARTICLE_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_2D_PARTICLE_TYPE_H
+
+typedef struct
+{
+  // pointers (x and y (temporary) coordinates and the number of elements (or particles)):
+  double* x;
+  double* y;
+  double* xtmp;
+  double* ytmp;
+  double* numel;
+  // actual placeholder (allocated on the heap) for storing the particle coordinates:
+  double* data;
+} particle_t;
+
+#endif
+
+
+/*
+
+Algorithms and Complexity					August 11, 2023
+
+source: particle.h
+author: @misael-diaz
+
+Synopsis:
+Defines the particle type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
@@ -1,42 +1,37 @@
-#ifndef GUARD_AC_CLOSEST_PAIR_2D_H
-#define GUARD_AC_CLOSEST_PAIR_2D_H
+#ifndef GUARD_AC_CLOSEST_PAIR_2D_UTIL_H
+#define GUARD_AC_CLOSEST_PAIR_2D_UTIL_H
 
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
+#include "particle.h"
 
 double urand(double const size);
 double getElapsedTime(const struct timespec* b, const struct timespec* e);
 void copy(const double* restrict src, double* restrict dst, size_t const numel);
-double* create(size_t const size);
-double* destroy(double* x);
+particle_t* create(size_t const numel);
+particle_t* destroy(particle_t* particles);
 
-int xcompare (const double* positions,
-              size_t const numel,
+int xcompare (const particle_t* particles,
               size_t const first,
               size_t const second);
 
-int ycompare (const double* positions,
-              size_t const numel,
+int ycompare (const particle_t* particles,
               size_t const first,
               size_t const second);
 
-bool sorted(const double* positions,
-            size_t const numel,
+bool sorted(const particle_t* particles,
             size_t const b,
             size_t const e,
-	    int (*comp) (const double*, size_t const, size_t const, size_t const));
+	    int (*comp) (const particle_t* particles, size_t const i, size_t const j));
 
 bool contains(const double* x, int64_t const b, int64_t const e, double const tgt);
 
-int64_t search (const double* positions,
-		size_t const numel,
-		int (*comp) (const double*, size_t const, size_t const, size_t const));
+int64_t search(const particle_t* particles,
+	       int (*comp) (const particle_t* particles, size_t const i, size_t const j));
 
-void sort(double* positions,
-	  size_t const size,
-	  size_t const numel,
-	  int (*comp) (const double*, size_t const, size_t const, size_t const));
+void sort(particle_t* particles,
+	  int (*comp) (const particle_t* particles, size_t const i, size_t const j));
 #endif
 
 


### PR DESCRIPTION
COMMENTS:
By adding the particle type the implementation details (or the internals) are better hidden from the user; as a consquence of this the interface looks cleaner.

The users need only to set how many particles (or points) do they want to run the implementation of the closest pair finding algorithm.

The time complexity of sort() is still O(N log N) as expected.

Valgrind reports no memory issues