### PR TITLE
uses brute force to find the closest pair [clang]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/pair.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/pair.h
@@ -1,0 +1,33 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_2D_PAIR_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_2D_PAIR_TYPE_H
+
+typedef struct
+{
+  size_t first;
+  size_t second;
+  double dist;
+} pair_t;
+
+#endif
+
+
+/*
+
+Algorithms and Complexity					August 14, 2023
+
+source: pair.h
+author: @misael-diaz
+
+Synopsis:
+Defines the pair type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
@@ -475,6 +475,27 @@ void sort (particle_t* particles,
 }
 
 
+// sets the closest pair (setter), the convention is that the smallest `id' is the first
+void setClosestPair(pair_t* closestPair,
+		    size_t const first,
+		    size_t const second,
+		    double const dist)
+{
+  if (first < second)
+  {
+    closestPair -> first = first;
+    closestPair -> second = second;
+    closestPair -> dist = dist;
+  }
+  else
+  {
+    closestPair -> first = second;
+    closestPair -> second = first;
+    closestPair -> dist = dist;
+  }
+}
+
+
 // allocates memory and initializes the particle positions
 particle_t* create (size_t const numel)
 {

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
+#include "pair.h"
 #include "particle.h"
 
 double urand(double const size);
@@ -32,6 +33,11 @@ int64_t search(const particle_t* particles,
 
 void sort(particle_t* particles,
 	  int (*comp) (const particle_t* particles, size_t const i, size_t const j));
+
+void setClosestPair(pair_t* closestPair,
+		    size_t const first,
+		    size_t const second,
+		    double const dist);
 #endif
 
 


### PR DESCRIPTION
COMMENTS:
makes sure there's an unique closest pair because that way we can be sure that if the divide and conquer algorithm finds a different pair is because there's something wrong with its implementation

disables previous tests because we know that the code passes those tests

valgrind reports no memory issues