### PR TITLE
solves 2d closest pair problem [clang]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/particle.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/particle.h
@@ -4,10 +4,12 @@
 typedef struct
 {
   // pointers (x and y (temporary) coordinates and the number of elements (or particles)):
+  double* id;
   double* x;
   double* y;
   double* xtmp;
   double* ytmp;
+  double* itmp;
   double* numel;
   // actual placeholder (allocated on the heap) for storing the particle coordinates:
   double* data;

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/test.c
@@ -5,15 +5,25 @@
 #include "util.h"	// uses user-defined utilities to find the closest pair
 
 #define RUNS 16
-#define REPS 256
+#define REPS 1024
 #define iNUMEL 2
 
 void test_sort();
 void complexity_sort();
 void test_bruteForce();
+void test_recurse();
+void test_recurse1();
+void test_recurse2();
+void test_recurse3();
+void divide(particle_t* particles, size_t const b, size_t const e, pair_t* closestPair);
+void recurse(particle_t* particles, size_t const b, size_t const e, pair_t* closestPair);
 
 int main ()
 {
+  test_recurse();
+  test_recurse1();
+  test_recurse2();
+  test_recurse3();
   test_bruteForce();
 //test_sort();
 //complexity_sort();
@@ -113,6 +123,252 @@ void bruteForce (const particle_t* particles, pair_t* closestPair)
 }
 
 
+// direct solution, updates the closest pair by considering a pair of particles
+void direct (const particle_t* particles,
+	     size_t const beg,
+	     size_t const end,
+	     pair_t* closestPair)
+{
+  size_t const offset = beg;
+  const double* x = (particles -> x + offset);
+  const double* y = (particles -> y + offset);
+  double const dist = (x[0] - x[1]) * (x[0] - x[1]) + (y[0] - y[1]) * (y[0] - y[1]);
+  double const dmin = closestPair -> dist;
+  if (dist < dmin)
+  {
+    size_t const first = beg;		// NOTE: neither `first' nor `second' are the
+    size_t const second = (beg + 1);	// actual particle IDs yet in this implementation
+    setClosestPair(closestPair, first, second, dist);
+  }
+}
+
+
+
+// prunes elements from the combined partition prior to using brute force to obtain the
+// closest pair
+void xcombine (particle_t* particles,
+	       size_t const beg,
+	       size_t const end,
+	       pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  size_t const beginLeft = beg;
+  size_t const endLeft = beg + (numel / 2);
+  size_t const beginRight = beg + (numel / 2);
+  size_t const endRight = beg + numel;
+
+  const double* x = particles -> x;
+  const double* y = particles -> y;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  double const dist = closestPair -> dist;
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const j = ( endLeft - (i + 1) );
+    double const d = (x[j] - x[beginRight]) * (x[j] - x[beginRight]);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = beginRight; i != endRight; ++i)
+  {
+    size_t const lastLeft = (endLeft - 1);
+    double const d = (x[i] - x[lastLeft]) * (x[i] - x[lastLeft]);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  double dmin = closestPair -> dist;
+  size_t first = closestPair -> first;
+  size_t second = closestPair -> second;
+  for (size_t i = bLeft; i != eLeft; ++i)
+  {
+    for (size_t j = bRight; j != eRight; ++j)
+    {
+      double const d = (x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]);
+      if (d < dmin)
+      {
+	// NOTE: neither `first' and `second' are the particle IDs yet due to the sorting
+	first = i;
+	second = j;
+	dmin = d;
+      }
+    }
+  }
+  setClosestPair(closestPair, first, second, dmin);
+}
+
+
+// as xcombine() but uses the y-component of the position vector to compute the distance
+void ycombine (particle_t* particles,
+	       size_t const beg,
+	       size_t const end,
+	       pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  size_t const beginLeft = beg;
+  size_t const endLeft = beg + (numel / 2);
+  size_t const beginRight = beg + (numel / 2);
+  size_t const endRight = beg + numel;
+
+  const double* x = particles -> x;
+  const double* y = particles -> y;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  double const dist = closestPair -> dist;
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const j = ( endLeft - (i + 1) );
+    double const d = (y[j] - y[beginRight]) * (y[j] - y[beginRight]);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = beginRight; i != endRight; ++i)
+  {
+    size_t const lastLeft = (endLeft - 1);
+    double const d = (y[i] - y[lastLeft]) * (y[i] - y[lastLeft]);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  double dmin = closestPair -> dist;
+  size_t first = closestPair -> first;
+  size_t second = closestPair -> second;
+  for (size_t i = bLeft; i != eLeft; ++i)
+  {
+    for (size_t j = bRight; j != eRight; ++j)
+    {
+      double const d = (x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]);
+      if (d < dmin)
+      {
+	// NOTE: neither `first' and `second' are the particle IDs yet due to the sorting
+	first = i;
+	second = j;
+	dmin = d;
+      }
+    }
+  }
+  setClosestPair(closestPair, first, second, dmin);
+}
+
+
+// as recurse() but partitions the system in the y dimension
+void divide (particle_t* particles,
+	     size_t const beg,
+	     size_t const end,
+	     pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  if (numel == 2)
+  {
+    direct(particles, beg, end, closestPair);
+  }
+  else
+  {
+    sort(particles, beg, end, ycompare);
+
+    size_t const beginLeft = beg;
+    size_t const endLeft = beg + (numel / 2);
+    size_t const size = ( (size_t) *(particles -> numel) );
+    pair_t closestPairLeft = { .first = size, .second = size, .dist = INFINITY };
+    recurse(particles, beginLeft, endLeft, &closestPairLeft);
+
+    size_t const beginRight = beg + (numel / 2);
+    size_t const endRight = beg + numel;
+    pair_t closestPairRight = { .first = size, .second = size, .dist = INFINITY };
+    recurse(particles, beginRight, endRight, &closestPairRight);
+
+    minClosestPair(closestPair, &closestPairLeft, &closestPairRight);
+
+    ycombine(particles, beg, end, closestPair);
+
+    // NOTE: we need to restore the x - y sorting because the xcombine() method at the
+    // level of the caller method recurse() expects it (as if we didn't call sort() here)
+    sort(particles, beg, end, xcompare);
+  }
+}
+
+
+// finds the closest pair recursively (incomplete implementation due to the IDs issue)
+void recurse (particle_t* particles,
+	      size_t const beg,
+	      size_t const end,
+	      pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  if (numel == 2)
+  {
+    direct(particles, beg, end, closestPair);
+  }
+  else
+  {
+    sort(particles, beg, end, xcompare);
+
+    size_t const beginLeft = beg;
+    size_t const endLeft = beg + (numel / 2);
+    size_t const size = ( (size_t) *(particles -> numel) );
+    pair_t closestPairLeft = { .first = size, .second = size, .dist = INFINITY };
+    divide(particles, beginLeft, endLeft, &closestPairLeft);
+
+    size_t const beginRight = beg + (numel / 2);
+    size_t const endRight = beg + numel;
+    pair_t closestPairRight = { .first = size, .second = size, .dist = INFINITY };
+    divide(particles, beginRight, endRight, &closestPairRight);
+
+    minClosestPair(closestPair, &closestPairLeft, &closestPairRight);
+
+    xcombine(particles, beg, end, closestPair);
+
+    // NOTE: we need to restore the y - x sorting because the ycombine() method at the
+    // level of the caller method divide() expects it (as if we didn't call sort() here)
+    sort(particles, beg, end, ycompare);
+  }
+}
+
+
 // tests the implementation of the brute force algorithm that finds the closest pair
 void test_bruteForce ()
 {
@@ -144,6 +400,182 @@ void test_bruteForce ()
   free(closestPair);
   closestPair = NULL;
   particles = destroy(particles);
+}
+
+
+// tests the implementation with problem 2.3.1-1 of reference [1]
+void test_recurse ()
+{
+  // note that we have added four more elements to meet create()'s requirements
+  double x[] = {2,  4, 5, 10, 13, 15, 17, 19, 22, 25, 29, 30, 64, -64, -64,  64};
+  double y[] = {7, 13, 7,  5,  9,  5,  7, 10,  7, 10, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+  particle_t* particles = create(numel);
+  if (particles == NULL)
+  {
+    return;
+  }
+
+  double* xdst = particles -> x;
+  double* ydst = particles -> y;
+  const double *xsrc = x;
+  const double *ysrc = y;
+  copy(xsrc, xdst, numel);
+  copy(ysrc, ydst, numel);
+
+  pair_t closestPairBruteForce = {.first = numel, .second = numel, .dist = -INFINITY};
+  bruteForce(particles, &closestPairBruteForce);
+
+  pair_t closestPairRecurse = {.first = numel, .second = numel, .dist = +INFINITY};
+  recurse(particles, 0, numel, &closestPairRecurse);
+
+  bool failed = (closestPairRecurse.dist != closestPairBruteForce.dist)? true : false;
+
+  printf("test-recurse[0]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  particles = destroy(particles);
+}
+
+
+// tests the implementation with problem 2.3.1-2 of reference [1]
+void test_recurse1 ()
+{
+  // note that we have added four more elements to meet create()'s requirements
+  double x[] = {1,  1, 7, 9, 12, 13, 20, 22, 23, 25, 26, 31, 64, -64, -64,  64};
+  double y[] = {2, 11, 8, 9, 13,  4,  8,  3, 12, 14,  7, 10, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+  particle_t* particles = create(numel);
+  if (particles == NULL)
+  {
+    return;
+  }
+
+  double* xdst = particles -> x;
+  double* ydst = particles -> y;
+  const double *xsrc = x;
+  const double *ysrc = y;
+  copy(xsrc, xdst, numel);
+  copy(ysrc, ydst, numel);
+
+  pair_t closestPairBruteForce = {.first = numel, .second = numel, .dist = -INFINITY};
+  bruteForce(particles, &closestPairBruteForce);
+
+  pair_t closestPairRecurse = {.first = numel, .second = numel, .dist = +INFINITY};
+  recurse(particles, 0, numel, &closestPairRecurse);
+
+  bool failed = (closestPairRecurse.dist != closestPairBruteForce.dist)? true : false;
+
+  printf("test-recurse[1]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  particles = destroy(particles);
+}
+
+
+// tests the implementation with problem 2.3.1-3 of reference [1]
+void test_recurse2 ()
+{
+  // note that we have added four more elements to meet create()'s requirements
+  double x[] = {2,  2, 5,  9, 11, 15, 17, 18, 22, 25, 28, 30, 64, -64, -64,  64};
+  double y[] = {2, 12, 4, 11,  4, 14, 13,  7,  4,  7, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+  particle_t* particles = create(numel);
+  if (particles == NULL)
+  {
+    return;
+  }
+
+  double* xdst = particles -> x;
+  double* ydst = particles -> y;
+  const double *xsrc = x;
+  const double *ysrc = y;
+  copy(xsrc, xdst, numel);
+  copy(ysrc, ydst, numel);
+
+  pair_t closestPairBruteForce = {.first = numel, .second = numel, .dist = -INFINITY};
+  bruteForce(particles, &closestPairBruteForce);
+
+  pair_t closestPairRecurse = {.first = numel, .second = numel, .dist = +INFINITY};
+  recurse(particles, 0, numel, &closestPairRecurse);
+
+  bool failed = (closestPairRecurse.dist != closestPairBruteForce.dist)? true : false;
+
+  printf("test-recurse[2]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  particles = destroy(particles);
+}
+
+
+void test_recurse3 ()
+{
+  bool failed = false;
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    particle_t* particles = create(numel);
+    if (particles == NULL)
+    {
+      printf("test-recurse3(): failed to allocate memory for the particle positions\n");
+      return;
+    }
+
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(particles);
+      pair_t closestPairBruteForce = {.first = numel, .second = numel, .dist = -INFINITY};
+      bruteForce(particles, &closestPairBruteForce);
+
+      pair_t closestPairRecurse = {.first = numel, .second = numel, .dist = +INFINITY};
+      recurse(particles, 0, numel, &closestPairRecurse);
+
+      if (closestPairRecurse.dist != closestPairBruteForce.dist)
+      {
+	failed = true;
+	break;
+      }
+    }
+
+    if (failed)
+    {
+      break;
+    }
+
+    particles = destroy(particles);
+    numel *= 2;
+  }
+
+  printf("test-recurse[3]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
 }
 
 
@@ -428,3 +860,9 @@ References:
 [1] JJ McConnell, Analysis of Algorithms, second edition.
 
 */
+
+
+// TODO:
+// [ ] fix the particle ID issue by tasking sort() with the manipulation of the IDs array
+// [ ] add test that checks that the IDs of the closest pair found by the brute force
+//     and recursive algorithms match

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/test.c
@@ -187,7 +187,7 @@ void test_sort ()
       copy(xsrc, xdst, numel);
       copy(ysrc, ydst, numel);
 
-      sort(particles, xcompare);
+      sort(particles, 0, numel, xcompare);
 
       // complains if there are out-of-order elements after invoking sort():
 
@@ -314,7 +314,7 @@ void complexity_sort ()
 
       clock_gettime(CLOCK_MONOTONIC_RAW, begin);
 
-      sort(particles, xcompare);
+      sort(particles, 0, numel, xcompare);
 
       clock_gettime(CLOCK_MONOTONIC_RAW, end);
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
@@ -498,10 +498,42 @@ void setClosestPair(pair_t* closestPair,
 }
 
 
+// implements a min() like method for pair objects
+void minClosestPair (pair_t* closestPair,
+		     const pair_t* closestPairLeft,
+		     const pair_t* closestPairRight)
+{
+  double dmin = INFINITY;
+  size_t first = 0xffffffffffffffff;
+  size_t second = 0xffffffffffffffff;
+  double const minDistLeft = closestPairLeft -> dist;
+  double const minDistRight = closestPairRight -> dist;
+  if (minDistLeft < minDistRight)
+  {
+    dmin = minDistLeft;
+    first = closestPairLeft -> first;
+    second = closestPairLeft -> second;
+  }
+  else
+  {
+    dmin = minDistRight;
+    first = closestPairRight -> first;
+    second = closestPairRight -> second;
+  }
+  setClosestPair(closestPair, first, second, dmin);
+}
+
+
 // allocates memory and initializes the particle positions
 particle_t* create (size_t const numel)
 {
   // performs sane checks:
+
+  if (numel == 0)
+  {
+    printf("create(): expects the number of particles to be finite\n");
+    return NULL;
+  }
 
   if (numel % 2)
   {
@@ -512,6 +544,13 @@ particle_t* create (size_t const numel)
   if (numel >= 0x7fffffffffffffff)
   {
     printf("create(): reserved values\n");
+    return NULL;
+  }
+
+  union { double data; uint64_t bin } mantissa = { .data = numel };
+  if ( (mantissa.bin & 0x000fffffffffffff) != 0 )
+  {
+    printf("create(): expects the number of particles to be a power of two\n");
     return NULL;
   }
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.c
@@ -441,16 +441,17 @@ static void combine(particle_t* particles,
 // particles	the particles sorted according to the supplied comparator
 
 
-void sort (particle_t* particles,
+void sort (particle_t* particles, size_t const beg, size_t const end,
 	   int (*comp) (const particle_t* particles, size_t const i, size_t const j))
 {
   // orders particles in pairs (that is, in partitions of size 2):
 
-  size_t const numel = ( (size_t) *(particles -> numel) );
+  size_t const numel = (end - beg);
   for (size_t i = 0; i != numel; i += 2)
   {
-    size_t const first = i;
-    size_t const second = (i + 1);
+    size_t const offset = beg;
+    size_t const first = (i + offset);
+    size_t const second = ( (i + 1) + offset );
     direct(particles, first, second, comp);
   }
 
@@ -465,13 +466,14 @@ void sort (particle_t* particles,
   {
     for (size_t i = 0; i != numel; i += stride)
     {
-      size_t const b = i;
-      size_t const e = (i + stride);
+      size_t const offset = beg;
+      size_t const b = (i + offset);
+      size_t const e = ( (i + stride) + offset );
       combine(particles, b, e, comp);
     }
   }
 
-  combine(particles, 0, numel, comp);
+  combine(particles, beg, end, comp);
 }
 
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
@@ -38,6 +38,10 @@ void setClosestPair(pair_t* closestPair,
 		    size_t const first,
 		    size_t const second,
 		    double const dist);
+
+void minClosestPair(pair_t* closestPair,
+		    const pair_t* closestPairLeft,
+		    const pair_t* closestPairRight);
 #endif
 
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
@@ -31,7 +31,7 @@ bool contains(const double* x, int64_t const b, int64_t const e, double const tg
 int64_t search(const particle_t* particles,
 	       int (*comp) (const particle_t* particles, size_t const i, size_t const j));
 
-void sort(particle_t* particles,
+void sort(particle_t* particles, size_t const beg, size_t const end,
 	  int (*comp) (const particle_t* particles, size_t const i, size_t const j));
 
 void setClosestPair(pair_t* closestPair,

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/2d-closest-pair/clang/util.h
@@ -7,6 +7,7 @@
 #include "pair.h"
 #include "particle.h"
 
+void iota (double* x, size_t const size);
 double urand(double const size);
 double getElapsedTime(const struct timespec* b, const struct timespec* e);
 void copy(const double* restrict src, double* restrict dst, size_t const numel);
@@ -42,6 +43,9 @@ void setClosestPair(pair_t* closestPair,
 void minClosestPair(pair_t* closestPair,
 		    const pair_t* closestPairLeft,
 		    const pair_t* closestPairRight);
+
+bool isEqualClosestPair(const pair_t* closestPair1, const pair_t* closestPair2);
+void logClosestPair(const pair_t* closestPair1);
 #endif
 
 


### PR DESCRIPTION
solves the 2D closest pair problem

the divide and conquer algorithm finds the same result as the brute force algorithm (both the IDs of the particles that comprise the closest pair and their separating distance)

only need to perform a time complexity analysis (to be done later)