### PR TITLE
improves interface closest pair [clang] [OOP]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/ensemble.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/ensemble.h
@@ -1,26 +1,26 @@
-#ifndef GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
-#define GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
+#ifndef GUARD_AC_CLOSEST_PAIR_OOP_ENSEMBLE_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_OOP_ENSEMBLE_TYPE_H
 
-#include "ensemble.h"
-#include "pair.h"
+#include "point.h"
 
-int search(const point_t* points, size_t const b, size_t const e, const point_t* target);
-double urand(double const size);
-ensemble_t* create(size_t const numel);
-ensemble_t* destroy(ensemble_t* ensemble);
-pair_t* deconstruct(pair_t* closestPair);
-pair_t* construct();
+typedef struct
+{
+  point_t* points;
+  point_t* temp;
+  size_t* numel;
+  void* data;
+} ensemble_t;
 
 #endif
 /*
 
 Algorithms and Complexity					August 16, 2023
 
-source: util.h
+source: ensemble.h
 author: @misael-diaz
 
 Synopsis:
-Header for the closest pair utilities.
+Defines the Ensemble (of points) type.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
@@ -14,8 +14,11 @@ int main ()
 }
 
 
-void generate (point_t* points, size_t const numel)
+void generate (ensemble_t* ensemble)
 {
+  size_t const numel = *(ensemble -> numel);
+  point_t* points = ensemble -> points;
+
   point_t* point = points;
   for (size_t i = 0; i != numel; ++i)
   {
@@ -32,11 +35,14 @@ void generate (point_t* points, size_t const numel)
 }
 
 
-bool hasDuplicateClosestPairs (const point_t* points, size_t const numel)
+bool hasDuplicateClosestPairs (const ensemble_t* ensemble)
 {
+  const point_t* points = ensemble -> points;
+  const point_t* point1 = points;
+
   double dmin1 = INFINITY;
   double dmin2 = INFINITY;
-  const point_t* point1 = points;
+  size_t const numel = *(ensemble -> numel);
   for (size_t i = 0; i != (numel - 1); ++i)
   {
     const point_t* point2 = (point1 + 1);
@@ -57,17 +63,20 @@ bool hasDuplicateClosestPairs (const point_t* points, size_t const numel)
 }
 
 
-void initialize (point_t* points, size_t const numel)
+void initialize (ensemble_t* ensemble)
 {
   do
   {
-    generate(points, numel);
-  } while ( hasDuplicateClosestPairs(points, numel) );
+    generate(ensemble);
+  } while ( hasDuplicateClosestPairs(ensemble) );
 }
 
 
-void bruteForce (const point_t* points, pair_t* closestPair, size_t const numel)
+void bruteForce (const ensemble_t* ensemble, pair_t* closestPair)
 {
+  size_t const numel = *(ensemble -> numel);
+  const point_t* points = ensemble -> points;
+
   size_t first = numel;
   size_t second = numel;
   double dmin = INFINITY;
@@ -101,21 +110,22 @@ void test_bruteForce ()
   }
 
   size_t const numel = iNUMEL;
-  point_t* points = create(numel);
-  initialize(points, numel);
+  ensemble_t* ensemble = create(numel);
+  initialize(ensemble);
 
-  point_t* point = points;
+  const point_t* points = ensemble -> points;
+  const point_t* point = points;
   for (size_t i = 0; i != numel; ++i)
   {
     point -> log(point);
     ++point;
   }
 
-  bruteForce(points, closestPair, numel);
+  bruteForce(ensemble, closestPair);
   printf("bruteForce(): ");
   closestPair -> log(closestPair);
 
-  points = destroy(points);
+  ensemble = destroy(ensemble);
   closestPair = deconstruct(closestPair);
 }
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
@@ -185,7 +185,7 @@ pair_t* deconstruct (pair_t* closestPair)
 }
 
 
-point_t* create (size_t const numel)
+ensemble_t* create (size_t const numel)
 {
   if (numel == 0)
   {
@@ -212,28 +212,62 @@ point_t* create (size_t const numel)
     return NULL;
   }
 
-  point_t* points = malloc( numel * sizeof(point_t) );
-  if (points == NULL)
+  size_t const size_points = numel * sizeof(point_t);
+  size_t const size_temp = numel * sizeof(point_t);
+  size_t const size_numel = 1 * sizeof(size_t);
+  size_t const size = size_points +
+		      size_temp +
+		      size_numel;
+
+  void* data = malloc(size);
+  if (data == NULL)
   {
+    printf("create(): failed to allocate data placeholder\n");
     return NULL;
   }
 
-  init(points, numel);
+  ensemble_t* ensemble = malloc( sizeof(ensemble_t) );
+  if (ensemble == NULL)
+  {
+    free(data);
+    data = NULL;
+    return NULL;
+  }
 
-  return points;
+  ensemble -> points = ( (point_t*) data );
+  ensemble -> temp = ensemble -> points + numel;
+  ensemble -> numel = ( (size_t*) (ensemble -> temp + numel) );
+  ensemble -> data = data;
+  data = NULL;
+
+  point_t* points = ensemble -> points;
+  point_t* temp = ensemble -> temp;
+
+  init(points, numel);
+  init(temp, numel);
+
+  *(ensemble -> numel) = numel;
+
+  return ensemble;
 }
 
 
-point_t* destroy (point_t* points)
+ensemble_t* destroy (ensemble_t* ensemble)
 {
-  if (points == NULL)
+  if (ensemble == NULL)
   {
-    return points;
+    return ensemble;
   }
 
-  free(points);
-  points = NULL;
-  return points;
+  free(ensemble -> data);
+  ensemble -> data = NULL;
+  ensemble -> points = NULL;
+  ensemble -> temp = NULL;
+  ensemble -> numel = NULL;
+
+  free(ensemble);
+  ensemble = NULL;
+  return ensemble;
 }
 
 


### PR DESCRIPTION
COMMENTS:
adds the ensemble type, this type allocates extra memory in advance for the sort() method (as in the procedural solution of this problem)

makes some functions look cleaner (with fewer arguments)

valgrind reports no memory issues