### PR TITLE
solves 2D closest pair problem [clang] [OOP]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/complexity-sort-plot.py
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/complexity-sort-plot.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Algorithms and Complexity                                       August 10, 2023
+
+source: complexity-sort-plot.py
+author: @misael-diaz
+
+Synopsis:
+Plots the time complexity of the implementation of the sorting algorithm sort().
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] R Johansson, Numerical Python: Scientific Computing and Data
+    Science Applications with NumPy, SciPy, and Matplotlib, 2nd edition
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+"""
+
+from numpy import loadtxt
+from numpy import log2 as log
+from matplotlib import pyplot as plt
+
+size, time = loadtxt('complexity-sort.txt').transpose()
+
+plt.close('all')
+plt.ion()
+fig, ax = plt.subplots()
+c = time[-1] / (size[-1] * log(size[-1]))
+ax.loglog(size, c * size * log(size), linestyle='--', color='black', label='theory')
+ax.loglog(size, time, color='red', label='numeric')
+ax.set_xlabel('size')
+ax.set_ylabel('time')
+ax.legend()

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/pair.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/pair.h
@@ -1,12 +1,22 @@
 #ifndef GUARD_AC_CLOSEST_PAIR_OOP_PAIR_TYPE_H
 #define GUARD_AC_CLOSEST_PAIR_OOP_PAIR_TYPE_H
 
+#define __PAIR_ID_TYPE size_t
+#define __PAIR_DISTANCE_TYPE double
+
 typedef struct
 {
-  size_t first;
-  size_t second;
-  double dist;
+// private:
+  __PAIR_ID_TYPE _first;
+  __PAIR_ID_TYPE _second;
+  __PAIR_DISTANCE_TYPE _dist;
+// public:
+  size_t (*getFirst)(const void* closestPair);
+  size_t (*getSecond)(const void* closestPair);
+  double (*getDistance)(const void* closestPair);
   void (*set)(void* closestPair, size_t const first, size_t const second, double const d);
+  void (*min)(void* closestPair, const void* pair1, const void* pair2);
+  bool (*cmp)(const void* pair1, const void* pair2);
   void (*log)(const void* closestPair);
 } pair_t;
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/point.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/point.h
@@ -1,15 +1,23 @@
 #ifndef GUARD_AC_CLOSEST_PAIR_OOP_POINT_TYPE_H
 #define GUARD_AC_CLOSEST_PAIR_OOP_POINT_TYPE_H
 
+#define __POINT_ID_TYPE size_t
+#define __POINT_POSITION_TYPE double
+
 typedef struct
 {
-  double x;
-  double y;
-  size_t id;
+// private:
+  __POINT_POSITION_TYPE _x;
+  __POINT_POSITION_TYPE _y;
+  __POINT_ID_TYPE _id;
+// public:
+  size_t (*getID) (const void* point);
   void (*set) (void* point, double const x, double const y, size_t const id);
   void (*log) (const void* point);
   void (*clone) (void* dst, const void* src);
   double (*dist) (const void* point1, const void* point2);
+  double (*dist_x) (const void* point1, const void* point2);
+  double (*dist_y) (const void* point1, const void* point2);
 } point_t;
 
 #endif

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
@@ -9,11 +9,13 @@
 
 void test_sort();
 void test_bruteForce();
+void complexity_sort();
 
 int main ()
 {
-  test_sort();
-  test_bruteForce();
+//test_sort();
+//test_bruteForce();
+  complexity_sort();
   return 0;
 }
 
@@ -177,6 +179,83 @@ void test_sort ()
 }
 
 
+void complexity_sort ()
+{
+  bool failed = false;
+  double etimes[RUNS];
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    ensemble_t* ensemble = create(numel);
+
+    double etime = 0;
+    struct timespec end;
+    struct timespec begin;
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ensemble);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &begin);
+
+      sort(ensemble, 0, numel, xcompare);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+      etime += getElapsedTime(&begin, &end);
+
+      failed = !sorted(ensemble, 0, numel, xcompare);
+      if (failed)
+      {
+	break;
+      }
+    }
+
+    etimes[run] = etime / ( (double) REPS );
+
+    if (failed)
+    {
+      ensemble = destroy(ensemble);
+      break;
+    }
+
+    ensemble = destroy(ensemble);
+    numel *= 2;
+  }
+
+  printf("test-sort[1]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  if (failed)
+  {
+    return;
+  }
+
+  const char fname[] = "complexity-sort.txt";
+  FILE* file = fopen(fname, "w");
+
+  if (file == NULL)
+  {
+    printf("complexity-sort(): IO ERROR with file %s\n", fname);
+    return;
+  }
+
+  numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    fprintf(file, "%lu %.16e\n", numel, etimes[run]);
+    numel *= 2;
+  }
+
+  fclose(file);
+  printf("complexity-sort(): time complexity results have been writen to %s\n", fname);
+}
 /*
 
 Algorithms and Complexity					August 16, 2023

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/test.c
@@ -9,13 +9,24 @@
 
 void test_sort();
 void test_bruteForce();
+void test_recurse();
+void test_recurse1();
+void test_recurse2();
+void test_recurse3();
 void complexity_sort();
+
+void divide(ensemble_t* ens, size_t const beg, size_t const end, pair_t* closestPair);
+void recurse(ensemble_t* ens, size_t const beg, size_t const end, pair_t* closestPair);
 
 int main ()
 {
-//test_sort();
+  test_recurse();
+  test_recurse1();
+  test_recurse2();
+  test_recurse3();
 //test_bruteForce();
-  complexity_sort();
+//test_sort();
+//complexity_sort();
   return 0;
 }
 
@@ -107,6 +118,264 @@ void bruteForce (const ensemble_t* ensemble, pair_t* closestPair)
 }
 
 
+void direct (const ensemble_t* ensemble,
+             size_t const beg,
+             size_t const end,
+             pair_t* closestPair)
+{
+  size_t const offset = beg;
+  const point_t* points = ensemble -> points + offset;
+  const point_t* point1 = points;
+  const point_t* point2 = points + 1;
+  double const dist = point1 -> dist(point1, point2);
+  double const dmin = closestPair -> getDistance(closestPair);
+  if (dist < dmin)
+  {
+    size_t const first = point1 -> getID(point1);
+    size_t const second = point2 -> getID(point2);
+    closestPair -> set(closestPair, first, second, dist);
+  }
+}
+
+
+void xcombine (ensemble_t* ensemble,
+	       size_t const beg,
+	       size_t const end,
+	       pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  size_t const beginLeft = beg;
+  size_t const endLeft = beg + (numel / 2);
+  size_t const beginRight = beg + (numel / 2);
+  size_t const endRight = beg + numel;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  const point_t* points = ensemble -> points;
+  double const dist = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const offset = ( endLeft - (i + 1) );
+    const point_t* pointLeft = points + offset;
+    const point_t* pointRight = points + beginRight;
+    double const d = pointLeft -> dist_x(pointLeft, pointRight);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = beginRight; i != endRight; ++i)
+  {
+    size_t const offset = i;
+    size_t const lastLeft = (endLeft - 1);
+    const point_t* pointLeft = points + lastLeft;
+    const point_t* pointRight = points + offset;
+    double const d = pointRight -> dist_x(pointRight, pointLeft);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  const point_t* pointLeft = points + bLeft;
+  size_t first = closestPair -> getFirst(closestPair);
+  size_t second = closestPair -> getSecond(closestPair);
+  double dmin = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (eLeft - bLeft); ++i)
+  {
+    const point_t* pointRight = points + bRight;
+    for (size_t j = 0; j != (eRight - bRight); ++j)
+    {
+      double const d = pointLeft -> dist(pointLeft, pointRight);
+      if (d < dmin)
+      {
+	first = pointLeft -> getID(pointLeft);
+	second = pointRight -> getID(pointRight);
+	dmin = d;
+      }
+      ++pointRight;
+    }
+    ++pointLeft;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+// as xcombine() but uses the y-axis distances to determine too far elements
+void ycombine (ensemble_t* ensemble,
+	       size_t const beg,
+	       size_t const end,
+	       pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  size_t const beginLeft = beg;
+  size_t const endLeft = beg + (numel / 2);
+  size_t const beginRight = beg + (numel / 2);
+  size_t const endRight = beg + numel;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  const point_t* points = ensemble -> points;
+  double const dist = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const offset = ( endLeft - (i + 1) );
+    const point_t* pointLeft = points + offset;
+    const point_t* pointRight = points + beginRight;
+    double const d = pointLeft -> dist_y(pointLeft, pointRight);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = beginRight; i != endRight; ++i)
+  {
+    size_t const offset = i;
+    size_t const lastLeft = (endLeft - 1);
+    const point_t* pointLeft = points + lastLeft;
+    const point_t* pointRight = points + offset;
+    double const d = pointRight -> dist_y(pointRight, pointLeft);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  const point_t* pointLeft = points + bLeft;
+  size_t first = closestPair -> getFirst(closestPair);
+  size_t second = closestPair -> getSecond(closestPair);
+  double dmin = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (eLeft - bLeft); ++i)
+  {
+    const point_t* pointRight = points + bRight;
+    for (size_t j = 0; j != (eRight - bRight); ++j)
+    {
+      double const d = pointLeft -> dist(pointLeft, pointRight);
+      if (d < dmin)
+      {
+	first = pointLeft -> getID(pointLeft);
+	second = pointRight -> getID(pointRight);
+	dmin = d;
+      }
+      ++pointRight;
+    }
+    ++pointLeft;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+// as recurse() but partitions the system in the y dimension
+void divide (ensemble_t* ensemble,
+	     size_t const beg,
+	     size_t const end,
+	     pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  if (numel == 2)
+  {
+    direct(ensemble, beg, end, closestPair);
+  }
+  else
+  {
+    sort(ensemble, beg, end, ycompare);
+
+    size_t const beginLeft = beg;
+    size_t const endLeft = beg + (numel / 2);
+    pair_t* closestPairLeft = construct();
+    recurse(ensemble, beginLeft, endLeft, closestPairLeft);
+
+    size_t const beginRight = beg + (numel / 2);
+    size_t const endRight = beg + numel;
+    pair_t* closestPairRight = construct();
+    recurse(ensemble, beginRight, endRight, closestPairRight);
+
+    closestPair -> min(closestPair, closestPairLeft, closestPairRight);
+
+    ycombine(ensemble, beg, end, closestPair);
+
+    // NOTE: we need to restore the x - y sorting because the xcombine() method at the
+    // level of the caller method recurse() expects it (as if we didn't call sort() here)
+    sort(ensemble, beg, end, xcompare);
+
+    closestPairLeft = deconstruct(closestPairLeft);
+    closestPairRight = deconstruct(closestPairRight);
+  }
+}
+
+
+void recurse (ensemble_t* ensemble,
+	      size_t const beg,
+	      size_t const end,
+	      pair_t* closestPair)
+{
+  size_t const numel = (end - beg);
+  if (numel == 2)
+  {
+    direct(ensemble, beg, end, closestPair);
+  }
+  else
+  {
+    sort(ensemble, beg, end, xcompare);
+
+    size_t const beginLeft = beg;
+    size_t const endLeft = beg + (numel / 2);
+    pair_t* closestPairLeft = construct();
+    divide(ensemble, beginLeft, endLeft, closestPairLeft);
+
+    size_t const beginRight = beg + (numel / 2);
+    size_t const endRight = beg + numel;
+    pair_t* closestPairRight = construct();
+    divide(ensemble, beginRight, endRight, closestPairRight);
+
+    closestPair -> min(closestPair, closestPairLeft, closestPairRight);
+
+    xcombine(ensemble, beg, end, closestPair);
+
+    // NOTE: we need to restore the y - x sorting because the ycombine() method at the
+    // level of the caller method recurse() expects it (as if we didn't call sort() here)
+    sort(ensemble, beg, end, ycompare);
+
+    closestPairLeft = deconstruct(closestPairLeft);
+    closestPairRight = deconstruct(closestPairRight);
+  }
+}
+
+
 void test_bruteForce ()
 {
   pair_t* closestPair = construct();
@@ -133,6 +402,229 @@ void test_bruteForce ()
 
   ensemble = destroy(ensemble);
   closestPair = deconstruct(closestPair);
+}
+
+
+// tests the implementation with problem 2.3.1-1 of reference [1]
+void test_recurse ()
+{
+  // note that we have added four more elements to meet create()'s requirements
+  double x[] = {2,  4, 5, 10, 13, 15, 17, 19, 22, 25, 29, 30, 64, -64, -64,  64};
+  double y[] = {7, 13, 7,  5,  9,  5,  7, 10,  7, 10, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = construct();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = construct();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = deconstruct(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ensemble = create(numel);
+  point_t* points = ensemble -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ensemble, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  recurse(ensemble, 0, numel, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[0]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ensemble = destroy(ensemble);
+  closestPairBruteForce = deconstruct(closestPairBruteForce);
+  closestPairRecurse = deconstruct(closestPairRecurse);
+}
+
+
+// tests the implementation with problem 2.3.1-2 of reference [1]
+void test_recurse1 ()
+{
+  double x[] = {1,  1, 7, 9, 12, 13, 20, 22, 23, 25, 26, 31, 64, -64, -64,  64};
+  double y[] = {2, 11, 8, 9, 13,  4,  8,  3, 12, 14,  7, 10, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = construct();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = construct();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = deconstruct(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ensemble = create(numel);
+  point_t* points = ensemble -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ensemble, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  recurse(ensemble, 0, numel, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[1]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ensemble = destroy(ensemble);
+  closestPairBruteForce = deconstruct(closestPairBruteForce);
+  closestPairRecurse = deconstruct(closestPairRecurse);
+}
+
+
+// tests the implementation with problem 2.3.1-3 of reference [1]
+void test_recurse2 ()
+{
+  double x[] = {2,  2, 5,  9, 11, 15, 17, 18, 22, 25, 28, 30, 64, -64, -64,  64};
+  double y[] = {2, 12, 4, 11,  4, 14, 13,  7,  4,  7, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = construct();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = construct();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = deconstruct(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ensemble = create(numel);
+  point_t* points = ensemble -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ensemble, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  recurse(ensemble, 0, numel, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[2]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ensemble = destroy(ensemble);
+  closestPairBruteForce = deconstruct(closestPairBruteForce);
+  closestPairRecurse = deconstruct(closestPairRecurse);
+}
+
+
+void test_recurse3 ()
+{
+  pair_t* closestPairBruteForce = construct();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = construct();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = deconstruct(closestPairBruteForce);
+    return;
+  }
+
+  bool failed = false;
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    ensemble_t* ensemble = create(numel);
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ensemble);
+
+      closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+      bruteForce(ensemble, closestPairBruteForce);
+
+      closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+      recurse(ensemble, 0, numel, closestPairRecurse);
+
+      failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+      if (failed)
+      {
+	printf("bruteForce(): ");
+	closestPairBruteForce -> log(closestPairBruteForce);
+	printf("recurse(): ");
+	closestPairRecurse -> log(closestPairRecurse);
+	break;
+      }
+    }
+
+    if (failed)
+    {
+      ensemble = destroy(ensemble);
+      break;
+    }
+
+    ensemble = destroy(ensemble);
+    numel *= 2;
+  }
+
+  printf("test-recurse[3]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  closestPairBruteForce = deconstruct(closestPairBruteForce);
+  closestPairRecurse = deconstruct(closestPairRecurse);
 }
 
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
@@ -6,6 +6,14 @@
 #include "util.h"
 
 
+double getElapsedTime (const struct timespec* b, const struct timespec* e)
+{
+  double begin = ( (double) (b -> tv_nsec) ) + 1.0e9 * ( (double) (b -> tv_sec) );
+  double end   = ( (double) (e -> tv_nsec) ) + 1.0e9 * ( (double) (e -> tv_sec) );
+  return (end - begin);
+}
+
+
 double urand (double const size)
 {
   double const lim = (size * size);

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.c
@@ -36,20 +36,20 @@ static int compare (double const x1, double const x2)
 
 int xcompare (const point_t* point1, const point_t* point2)
 {
-  double const x1 = point1 -> x;
-  double const y1 = point1 -> y;
-  double const x2 = point2 -> x;
-  double const y2 = point2 -> y;
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
   return ( (x1 != x2)? compare(x1, x2) : compare(y1, y2) );
 }
 
 
 int ycompare (const point_t* point1, const point_t* point2)
 {
-  double const x1 = point1 -> x;
-  double const y1 = point1 -> y;
-  double const x2 = point2 -> x;
-  double const y2 = point2 -> y;
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
   return ( (y1 != y2)? compare(y1, y2) : compare(x1, x2) );
 }
 
@@ -57,9 +57,16 @@ int ycompare (const point_t* point1, const point_t* point2)
 static void setter (void* vpoint, double const x, double const y, size_t const id)
 {
   point_t* point = vpoint;
-  point -> x = x;
-  point -> y = y;
-  point -> id = id;
+  point -> _x = x;
+  point -> _y = y;
+  point -> _id = id;
+}
+
+
+static size_t id_getter (const void* vpoint)
+{
+  const point_t* point = vpoint;
+  return (point -> _id);
 }
 
 
@@ -67,25 +74,25 @@ static void cloner (void* vdst, const void* vsrc)
 {
   point_t* dst = vdst;
   const point_t* src = vsrc;
-  dst -> x = src -> x;
-  dst -> y = src -> y;
-  dst -> id = src -> id;
+  dst -> _x = src -> _x;
+  dst -> _y = src -> _y;
+  dst -> _id = src -> _id;
 }
 
 
 static void logger (const void* vpoint)
 {
   const point_t* point = vpoint;
-  double const x = point -> x;
-  double const y = point -> y;
-  size_t const id = point -> id;
+  double const x = point -> _x;
+  double const y = point -> _y;
+  size_t const id = point -> _id;
   printf("x: %+e y: %+e id: %lu\n", x, y, id);
 }
 
 
 bool isEqual (const point_t* point1, const point_t* point2)
 {
-  return ( (xcompare(point1, point2) == 0) && (point1 -> id == point2 -> id) );
+  return ( (xcompare(point1, point2) == 0) && (point1 -> _id == point2 -> _id) );
 }
 
 
@@ -108,11 +115,31 @@ static double distance (const void* vpoint1, const void* vpoint2)
 {
   const point_t* point1 = vpoint1;
   const point_t* point2 = vpoint2;
-  double const x1 = point1 -> x;
-  double const y1 = point1 -> y;
-  double const x2 = point2 -> x;
-  double const y2 = point2 -> y;
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
   return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) );
+}
+
+
+static double distance_x (const void* vpoint1, const void* vpoint2)
+{
+  const point_t* point1 = vpoint1;
+  const point_t* point2 = vpoint2;
+  double const x1 = point1 -> _x;
+  double const x2 = point2 -> _x;
+  return ( (x1 - x2) * (x1 - x2) );
+}
+
+
+static double distance_y (const void* vpoint1, const void* vpoint2)
+{
+  const point_t* point1 = vpoint1;
+  const point_t* point2 = vpoint2;
+  double const y1 = point1 -> _y;
+  double const y2 = point2 -> _y;
+  return ( (y1 - y2) * (y1 - y2) );
 }
 
 
@@ -141,9 +168,33 @@ void init (point_t* points, size_t const numel)
     point -> log = logger;
     point -> clone = cloner;
     point -> dist = distance;
+    point -> dist_x = distance_x;
+    point -> dist_y = distance_y;
+    point -> getID = id_getter;
     point -> set(point, x, y, id);
     ++point;
   }
+}
+
+
+static size_t getFirstClosestPair (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _first;
+}
+
+
+static size_t getSecondClosestPair (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _second;
+}
+
+
+static double getDistanceClosestPair (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _dist;
 }
 
 
@@ -155,26 +206,72 @@ static void setClosestPair (void* vclosestPair,
   pair_t* closestPair = vclosestPair;
   if (first < second)
   {
-    closestPair -> first = first;
-    closestPair -> second = second;
-    closestPair -> dist = dist;
+    closestPair -> _first = first;
+    closestPair -> _second = second;
+    closestPair -> _dist = dist;
   }
   else
   {
-    closestPair -> first = second;
-    closestPair -> second = first;
-    closestPair -> dist = dist;
+    closestPair -> _first = second;
+    closestPair -> _second = first;
+    closestPair -> _dist = dist;
   }
+}
+
+
+static void minClosestPair (void* vclosestPair,
+			    const void* vclosestPairLeft,
+			    const void* vclosestPairRight)
+{
+  pair_t* closestPair = vclosestPair;
+  const pair_t* closestPairLeft = vclosestPairLeft;
+  const pair_t* closestPairRight = vclosestPairRight;
+
+  double dmin = INFINITY;
+  size_t first = 0xffffffffffffffff;
+  size_t second = 0xffffffffffffffff;
+  double const minDistLeft = closestPairLeft -> _dist;
+  double const minDistRight = closestPairRight -> _dist;
+  if (minDistLeft < minDistRight)
+  {
+    dmin = minDistLeft;
+    first = closestPairLeft -> _first;
+    second = closestPairLeft -> _second;
+  }
+  else
+  {
+    dmin = minDistRight;
+    first = closestPairRight -> _first;
+    second = closestPairRight -> _second;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
 }
 
 
 static void logClosestPair (const void* vclosestPair)
 {
   const pair_t* closestPair = vclosestPair;
-  double const first = closestPair -> first;
-  double const second = closestPair -> second;
-  double const distance = closestPair -> dist;
-  printf("first: %.0f second: %.0f distance: %e\n", first, second, distance);
+  size_t const first = closestPair -> _first;
+  size_t const second = closestPair -> _second;
+  double const distance = closestPair -> _dist;
+  printf("first: %lu second: %lu distance: %e\n", first, second, distance);
+}
+
+
+bool cmpClosestPair (const void* vclosestPair1, const void* vclosestPair2)
+{
+  const pair_t* closestPair1 = vclosestPair1;
+  const pair_t* closestPair2 = vclosestPair2;
+
+  size_t const i = closestPair1 -> _first;
+  size_t const j = closestPair1 -> _second;
+  double const d1 = closestPair1 -> _dist;
+
+  size_t const n = closestPair2 -> _first;
+  size_t const m = closestPair2 -> _second;
+  double const d2 = closestPair2 -> _dist;
+
+  return ( ( (i == n) && (j == m) && (d1 == d2) )? true : false );
 }
 
 
@@ -199,8 +296,8 @@ bool sorted (const ensemble_t* ensemble, size_t const beg, size_t const end,
 }
 
 
-void direct(ensemble_t* ensemble, size_t const beg, size_t const end,
-	    int (*comp) (const point_t* point1, const point_t* point2))
+static void direct (ensemble_t* ensemble, size_t const beg, size_t const end,
+		    int (*comp) (const point_t* point1, const point_t* point2))
 {
   size_t const offset = beg;
   point_t* point1 = ensemble -> points + offset;
@@ -216,8 +313,8 @@ void direct(ensemble_t* ensemble, size_t const beg, size_t const end,
 }
 
 
-void combine (ensemble_t* ensemble, size_t const beg, size_t const end,
-	      int (*comp) (const point_t* point1, const point_t* point2))
+static void combine(ensemble_t* ensemble, size_t const beg, size_t const end,
+		    int (*comp) (const point_t* point1, const point_t* point2))
 {
   size_t const beginLeft = beg;
   size_t const endLeft = beg + ( (end - beg) / 2 );
@@ -306,11 +403,16 @@ pair_t* construct ()
     return NULL;
   }
 
-  closestPair -> first = 0xffffffffffffffff;
-  closestPair -> second = 0xffffffffffffffff;
-  closestPair -> dist = INFINITY;
+  closestPair -> _first = 0xffffffffffffffff;
+  closestPair -> _second = 0xffffffffffffffff;
+  closestPair -> _dist = INFINITY;
   closestPair -> set = setClosestPair;
+  closestPair -> min = minClosestPair;
+  closestPair -> cmp = cmpClosestPair;
   closestPair -> log = logClosestPair;
+  closestPair -> getFirst = getFirstClosestPair;
+  closestPair -> getSecond = getSecondClosestPair;
+  closestPair -> getDistance = getDistanceClosestPair;
   return closestPair;
 }
 

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/oop-closest-pair/clang/util.h
@@ -1,12 +1,15 @@
 #ifndef GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
 #define GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
 
+#include <time.h>
 #include "ensemble.h"
 #include "pair.h"
 
+double getElapsedTime (const struct timespec* b, const struct timespec* e);
 int search(const point_t* points, size_t const b, size_t const e, const point_t* target);
 double urand(double const size);
 int xcompare (const point_t* p, const point_t* q);
+int ycompare (const point_t* p, const point_t* q);
 bool sorted(const ensemble_t* ensemble, size_t const b, size_t const e,
 	    int (*comp) (const point_t* p, const point_t* q));
 void sort(ensemble_t* ensemble, size_t const b, size_t const e,


### PR DESCRIPTION
closes #102

Used an array instead of a vector to store the points because the number of points in the ensemble is always known and constant (not an inherent dynamic problem).

Did not use opaque types (as described in the issue) to "hide" the private attributes of the points; instead adopted what python developers do to write OOP code.

Used setters to avoid needless memory (de)allocations which only hurt performance; see for instance that the method generate() simply invokes the setter to change the point coordinates if those are already taken. This is more efficient in terms of memory. To protect (to some extent) the data from unintentional changes I used the `const` qualifier (of course you can discard the qualifier but if you are paying attention to the compiler warnings that can save you from yourself)

this OOP implementation is as fast (in terms of orders of magnitude) as the procedural implementation