### PR TITLE
adds optimal solution [clang] [OOP] [Python]

### DIFF
--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/Makefile
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/Makefile
@@ -1,0 +1,40 @@
+#!/usr/bin/make
+#
+# Algorithms and Complexity				August 24, 2023
+#
+# source: Makefile
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(TESTS)
+
+$(TEST_BIN): $(OBJECTS)
+	$(CC) $(CCOPT) $(OBJECTS) -o $(TEST_BIN) $(LIBS)
+
+$(POINT_O): $(POINT_H) $(POINT_C)
+	$(CC) $(CCOPT) -c $(POINT_C) -o $(POINT_O)
+
+$(PAIR_O): $(POINT_O) $(PAIR_H) $(PAIR_C)
+	$(CC) $(CCOPT) -c $(PAIR_C) -o $(PAIR_O)
+
+$(ENSEMBLE_O): $(POINT_O) $(ENSEMBLE_H) $(ENSEMBLE_C)
+	$(CC) $(CCOPT) -c $(ENSEMBLE_C) -o $(ENSEMBLE_O)
+
+$(UTIL_O): $(POINT_O) $(PAIR_O) $(ENSEMBLE_O) $(UTIL_H) $(UTIL_C)
+	$(CC) $(CCOPT) -c $(UTIL_C) -o $(UTIL_O)
+
+$(TEST_O): $(UTIL_O) $(TEST_C)
+	$(CC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
+
+clean:
+	/bin/rm -rf *.o *.bin

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/complexity-recurse-plot.py
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/complexity-recurse-plot.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Algorithms and Complexity                                       August 10, 2023
+
+source: complexity-recurse-plot.py
+author: @misael-diaz
+
+Synopsis:
+Plots the time complexity of the implementation of the divide and conquer algorithm that
+finds the closest pair.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] R Johansson, Numerical Python: Scientific Computing and Data
+    Science Applications with NumPy, SciPy, and Matplotlib, 2nd edition
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+"""
+
+from numpy import loadtxt
+from numpy import log2 as log
+from matplotlib import pyplot as plt
+
+size, time = loadtxt('complexity-recurse.txt').transpose()
+
+plt.close('all')
+plt.ion()
+fig, ax = plt.subplots()
+c = time[-1] / (size[-1] * log(size[-1]))
+ax.loglog(size, c * size * log(size), linestyle='--', color='black', label='theory')
+ax.loglog(size, time, color='red', label='numeric')
+ax.set_xlabel('size')
+ax.set_ylabel('time')
+ax.legend()

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/complexity-sort-plot.py
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/complexity-sort-plot.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Algorithms and Complexity                                       August 10, 2023
+
+source: complexity-sort-plot.py
+author: @misael-diaz
+
+Synopsis:
+Plots the time complexity of the implementation of the sorting algorithm sort().
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] R Johansson, Numerical Python: Scientific Computing and Data
+    Science Applications with NumPy, SciPy, and Matplotlib, 2nd edition
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+"""
+
+from numpy import loadtxt
+from numpy import log2 as log
+from matplotlib import pyplot as plt
+
+size, time = loadtxt('complexity-sort.txt').transpose()
+
+plt.close('all')
+plt.ion()
+fig, ax = plt.subplots()
+c = time[-1] / (size[-1] * log(size[-1]))
+ax.loglog(size, c * size * log(size), linestyle='--', color='black', label='theory')
+ax.loglog(size, time, color='red', label='numeric')
+ax.set_xlabel('size')
+ax.set_ylabel('time')
+ax.legend()

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/ensemble.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/ensemble.c
@@ -1,0 +1,133 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "ensemble.h"
+
+extern point_namespace_t const point;
+
+static void cloner (void* vdestination, const void* vsource)
+{
+  const ensemble_t* source = vsource;
+  ensemble_t* destination = vdestination;
+  const point_t* src = source -> points;
+  point_t* dst = destination -> points;
+  size_t const numel = *(source -> numel);
+  for (size_t i = 0; i != numel; ++i)
+  {
+    dst -> clone(dst, src);
+    ++src;
+    ++dst;
+  }
+}
+
+static ensemble_t* construct (size_t const numel)
+{
+  if (numel == 0)
+  {
+    printf("create(): expects the number of particles to be finite\n");
+    return NULL;
+  }
+
+  if (numel % 2)
+  {
+    printf("create(): expects the number of particles to be even\n");
+    return NULL;
+  }
+
+  if (numel >= 0x7fffffff)
+  {
+    printf("create(): reserved value\n");
+    return NULL;
+  }
+
+  union { double data; uint64_t bin; } mantissa = { .data = numel };
+  if ( (mantissa.bin & 0x000fffffffffffff) != 0 )
+  {
+    printf("create(): expects the number of particles to be a power of two\n");
+    return NULL;
+  }
+
+  size_t const size_points = numel * sizeof(point_t);
+  size_t const size_temp = numel * sizeof(point_t);
+  size_t const size_numel = 1 * sizeof(size_t);
+  size_t const size = size_points +
+		      size_temp +
+		      size_numel;
+
+  void* data = malloc(size);
+  if (data == NULL)
+  {
+    printf("create(): failed to allocate data placeholder\n");
+    return NULL;
+  }
+
+  ensemble_t* ensemble = malloc( sizeof(ensemble_t) );
+  if (ensemble == NULL)
+  {
+    free(data);
+    data = NULL;
+    return NULL;
+  }
+
+  ensemble -> points = ( (point_t*) data );
+  ensemble -> temp = ensemble -> points + numel;
+  ensemble -> numel = ( (size_t*) (ensemble -> temp + numel) );
+  ensemble -> data = data;
+  data = NULL;
+
+  point_t* points = ensemble -> points;
+  point_t* temp = ensemble -> temp;
+
+  point.initializer(points, numel);
+  point.initializer(temp, numel);
+
+  *(ensemble -> numel) = numel;
+
+  ensemble -> clone = cloner;
+
+  return ensemble;
+}
+
+static ensemble_t* deconstruct (ensemble_t* ensemble)
+{
+  if (ensemble == NULL)
+  {
+    return ensemble;
+  }
+
+  free(ensemble -> data);
+  ensemble -> data = NULL;
+  ensemble -> points = NULL;
+  ensemble -> temp = NULL;
+  ensemble -> numel = NULL;
+
+  free(ensemble);
+  ensemble = NULL;
+  return ensemble;
+}
+
+ensemble_namespace_t const ensemble = {
+  .create = construct,
+  .destroy = deconstruct
+};
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: ensemble.c
+author: @misael-diaz
+
+Synopsis:
+Defines the (de)constructor of the ensemble type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/ensemble.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/ensemble.h
@@ -1,0 +1,41 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_OOP_ENSEMBLE_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_OOP_ENSEMBLE_TYPE_H
+
+#include "point.h"
+
+typedef struct
+{
+  point_t* points;
+  point_t* temp;
+  size_t* numel;
+  void* data;
+  void (*clone) (void* dst, const void* src);
+} ensemble_t;
+
+typedef struct
+{
+  ensemble_t* (*create) (size_t const numel);
+  ensemble_t* (*destroy) (ensemble_t* ensemble);
+} ensemble_namespace_t;
+
+#endif
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: ensemble.h
+author: @misael-diaz
+
+Synopsis:
+Defines the Ensemble (of points) type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/make-inc
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/make-inc
@@ -1,0 +1,50 @@
+#
+# Algorithms and Complexity				August 24, 2023
+#
+# source: make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# clang compiler
+CC = gcc
+
+# options
+CCOPT = -mavx2 -O2 -ftree-vectorize -fopt-info-optimized=opts.log
+CCOPT = -mavx2 -O2 -ftree-vectorize -fopt-info-missed=missed-opts.log
+CCOPT = -g -Wall -Wextra -O0
+
+# libraries
+LIBS = -lm
+
+# headers
+POINT_H = point.h
+PAIR_H = pair.h
+ENSEMBLE_H = ensemble.h
+UTIL_H = util.h
+
+# sources
+POINT_C = point.c
+PAIR_C = pair.c
+ENSEMBLE_C = ensemble.c
+UTIL_C = util.c
+TEST_C = test.c
+
+# objects
+POINT_O = point.o
+PAIR_O = pair.o
+ENSEMBLE_O = ensemble.o
+UTIL_O = util.o
+TEST_O = test.o
+OBJECTS = $(POINT_O) $(PAIR_O) $(ENSEMBLE_O) $(UTIL_O) $(TEST_O)
+
+# executables
+TEST_BIN = test.bin
+TESTS = $(TEST_BIN)

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/pair.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/pair.c
@@ -1,0 +1,167 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include "pair.h"
+
+
+static size_t get_first (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _first;
+}
+
+
+static size_t get_second (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _second;
+}
+
+
+static double get_distance (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  return closestPair -> _dist;
+}
+
+
+static void setter (void* vclosestPair,
+		    size_t const first,
+		    size_t const second,
+		    double const dist)
+{
+  pair_t* closestPair = vclosestPair;
+  if (first < second)
+  {
+    closestPair -> _first = first;
+    closestPair -> _second = second;
+    closestPair -> _dist = dist;
+  }
+  else
+  {
+    closestPair -> _first = second;
+    closestPair -> _second = first;
+    closestPair -> _dist = dist;
+  }
+}
+
+
+static void minimum (void* vclosestPair,
+		     const void* vclosestPairLeft,
+		     const void* vclosestPairRight)
+{
+  pair_t* closestPair = vclosestPair;
+  const pair_t* closestPairLeft = vclosestPairLeft;
+  const pair_t* closestPairRight = vclosestPairRight;
+
+  double dmin = INFINITY;
+  size_t first = 0xffffffffffffffff;
+  size_t second = 0xffffffffffffffff;
+  double const minDistLeft = closestPairLeft -> _dist;
+  double const minDistRight = closestPairRight -> _dist;
+  if (minDistLeft < minDistRight)
+  {
+    dmin = minDistLeft;
+    first = closestPairLeft -> _first;
+    second = closestPairLeft -> _second;
+  }
+  else
+  {
+    dmin = minDistRight;
+    first = closestPairRight -> _first;
+    second = closestPairRight -> _second;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+static void logger (const void* vclosestPair)
+{
+  const pair_t* closestPair = vclosestPair;
+  size_t const first = closestPair -> _first;
+  size_t const second = closestPair -> _second;
+  double const distance = closestPair -> _dist;
+  printf("first: %lu second: %lu distance: %e\n", first, second, distance);
+}
+
+
+static bool comparator (const void* vclosestPair1, const void* vclosestPair2)
+{
+  const pair_t* closestPair1 = vclosestPair1;
+  const pair_t* closestPair2 = vclosestPair2;
+
+  size_t const i = closestPair1 -> _first;
+  size_t const j = closestPair1 -> _second;
+  double const d1 = closestPair1 -> _dist;
+
+  size_t const n = closestPair2 -> _first;
+  size_t const m = closestPair2 -> _second;
+  double const d2 = closestPair2 -> _dist;
+
+  return ( ( (i == n) && (j == m) && (d1 == d2) )? true : false );
+}
+
+
+static pair_t* construct ()
+{
+  pair_t* closestPair = malloc( sizeof(pair_t) );
+  if (closestPair == NULL)
+  {
+    printf("construct(): insufficient memory to allocate the closest pair\n");
+    return NULL;
+  }
+
+  closestPair -> _first = 0xffffffffffffffff;
+  closestPair -> _second = 0xffffffffffffffff;
+  closestPair -> _dist = INFINITY;
+  closestPair -> set = setter;
+  closestPair -> min = minimum;
+  closestPair -> cmp = comparator;
+  closestPair -> log = logger;
+  closestPair -> getFirst = get_first;
+  closestPair -> getSecond = get_second;
+  closestPair -> getDistance = get_distance;
+  return closestPair;
+}
+
+
+static pair_t* deconstruct (pair_t* closestPair)
+{
+  if (closestPair == NULL)
+  {
+    return closestPair;
+  }
+
+  free(closestPair);
+  closestPair = NULL;
+  return closestPair;
+}
+
+
+pair_namespace_t const pair = {
+  .create = construct,
+  .destroy = deconstruct
+};
+
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: pair.c
+author: @misael-diaz
+
+Synopsis:
+Defines methods for the pair type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/pair.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/pair.h
@@ -1,0 +1,51 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_OOP_PAIR_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_OOP_PAIR_TYPE_H
+
+#define __PAIR_ID_TYPE size_t
+#define __PAIR_DISTANCE_TYPE double
+
+typedef struct
+{
+// private:
+  __PAIR_ID_TYPE _first;
+  __PAIR_ID_TYPE _second;
+  __PAIR_DISTANCE_TYPE _dist;
+// public:
+  size_t (*getFirst)(const void* closestPair);
+  size_t (*getSecond)(const void* closestPair);
+  double (*getDistance)(const void* closestPair);
+  void (*set)(void* closestPair, size_t const first, size_t const second, double const d);
+  void (*min)(void* closestPair, const void* pair1, const void* pair2);
+  bool (*cmp)(const void* pair1, const void* pair2);
+  void (*log)(const void* closestPair);
+} pair_t;
+
+typedef struct
+{
+  pair_t* (*create) ();
+  pair_t* (*destroy) (pair_t* closestPair);
+} pair_namespace_t;
+
+#endif
+
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: pair.h
+author: @misael-diaz
+
+Synopsis:
+Defines the pair type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/point.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/point.c
@@ -1,0 +1,158 @@
+#include <stdio.h>
+#include <math.h>
+#include "point.h"
+
+
+static int compare (double const x1, double const x2)
+{
+  if (x1 == x2)
+  {
+    return 0;
+  }
+  else if (x1 > x2)
+  {
+    return 1;
+  }
+  else
+  {
+    return -1;
+  }
+}
+
+
+static int xcompare (const point_t* point1, const point_t* point2)
+{
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
+  return ( (x1 != x2)? compare(x1, x2) : compare(y1, y2) );
+}
+
+
+static int ycompare (const point_t* point1, const point_t* point2)
+{
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
+  return ( (y1 != y2)? compare(y1, y2) : compare(x1, x2) );
+}
+
+
+static void setter (void* vpoint, double const x, double const y, size_t const id)
+{
+  point_t* point = vpoint;
+  point -> _x = x;
+  point -> _y = y;
+  point -> _id = id;
+}
+
+
+static size_t id_getter (const void* vpoint)
+{
+  const point_t* point = vpoint;
+  return (point -> _id);
+}
+
+
+static void cloner (void* vdst, const void* vsrc)
+{
+  point_t* dst = vdst;
+  const point_t* src = vsrc;
+  dst -> _x = src -> _x;
+  dst -> _y = src -> _y;
+  dst -> _id = src -> _id;
+}
+
+
+static void logger (const void* vpoint)
+{
+  const point_t* point = vpoint;
+  double const x = point -> _x;
+  double const y = point -> _y;
+  size_t const id = point -> _id;
+  printf("x: %+e y: %+e id: %lu\n", x, y, id);
+}
+
+
+static double distance (const void* vpoint1, const void* vpoint2)
+{
+  const point_t* point1 = vpoint1;
+  const point_t* point2 = vpoint2;
+  double const x1 = point1 -> _x;
+  double const y1 = point1 -> _y;
+  double const x2 = point2 -> _x;
+  double const y2 = point2 -> _y;
+  return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) );
+}
+
+
+static double distance_x (const void* vpoint1, const void* vpoint2)
+{
+  const point_t* point1 = vpoint1;
+  const point_t* point2 = vpoint2;
+  double const x1 = point1 -> _x;
+  double const x2 = point2 -> _x;
+  return ( (x1 - x2) * (x1 - x2) );
+}
+
+
+static double distance_y (const void* vpoint1, const void* vpoint2)
+{
+  const point_t* point1 = vpoint1;
+  const point_t* point2 = vpoint2;
+  double const y1 = point1 -> _y;
+  double const y2 = point2 -> _y;
+  return ( (y1 - y2) * (y1 - y2) );
+}
+
+
+static void init (point_t* points, size_t const numel)
+{
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    size_t const id = i;
+    double const x = INFINITY;
+    double const y = INFINITY;
+    point -> set = setter;
+    point -> log = logger;
+    point -> clone = cloner;
+    point -> dist = distance;
+    point -> dist_x = distance_x;
+    point -> dist_y = distance_y;
+    point -> getID = id_getter;
+    point -> set(point, x, y, id);
+    ++point;
+  }
+}
+
+
+point_namespace_t const point = {
+  .initializer = init,
+  .xcomparator = xcompare,
+  .ycomparator = ycompare
+};
+
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: point.c
+author: @misael-diaz
+
+Synopsis:
+Defines methods for points.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/point.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/point.h
@@ -1,0 +1,50 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_OOP_POINT_TYPE_H
+#define GUARD_AC_CLOSEST_PAIR_OOP_POINT_TYPE_H
+
+#define __POINT_ID_TYPE size_t
+#define __POINT_POSITION_TYPE double
+
+typedef struct
+{
+// private:
+  __POINT_POSITION_TYPE _x;
+  __POINT_POSITION_TYPE _y;
+  __POINT_ID_TYPE _id;
+// public:
+  size_t (*getID) (const void* point);
+  void (*set) (void* point, double const x, double const y, size_t const id);
+  void (*log) (const void* point);
+  void (*clone) (void* dst, const void* src);
+  double (*dist) (const void* point1, const void* point2);
+  double (*dist_x) (const void* point1, const void* point2);
+  double (*dist_y) (const void* point1, const void* point2);
+} point_t;
+
+typedef struct
+{
+  void (*initializer) (point_t* points, size_t const numel);
+  int  (*xcomparator) (const point_t* point1, const point_t* point2);
+  int  (*ycomparator) (const point_t* point1, const point_t* point2);
+} point_namespace_t;
+
+#endif
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: point.h
+author: @misael-diaz
+
+Synopsis:
+Defines the 2D Point type.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/test.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/test.c
@@ -1,0 +1,957 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include "util.h"
+
+#define RUNS 16
+#define REPS 1024
+#define iNUMEL 2
+
+extern point_namespace_t const point;
+extern ensemble_namespace_t const ensemble;
+extern pair_namespace_t const pair;
+
+void test_sort();
+void test_bruteForce();
+void test_recurse();
+void test_recurse1();
+void test_recurse2();
+void test_recurse3();
+void complexity_sort();
+void complexity_recurse();
+
+void divide(const ensemble_t* Ex, const ensemble_t* Ey, pair_t* closestPair);
+void recurse(const ensemble_t* Ex, const ensemble_t* Ey, pair_t* closestPair);
+
+int main ()
+{
+  test_sort();
+  test_recurse();
+  test_recurse1();
+  test_recurse2();
+  test_recurse3();
+  test_bruteForce();
+  complexity_sort();
+  complexity_recurse();
+  return 0;
+}
+
+
+void generate (ensemble_t* ens)
+{
+  size_t const numel = *(ens -> numel);
+  point_t* points = ens -> points;
+
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    do
+    {
+      size_t const id = i;
+      double x = urand(numel);
+      double y = urand(numel);
+      point -> set(point, x, y, id);
+    }
+    while (search(points, 0, i, point) != -1);
+    ++point;
+  }
+}
+
+
+bool hasDuplicateClosestPairs (const ensemble_t* ens)
+{
+  const point_t* points = ens -> points;
+  const point_t* point1 = points;
+
+  double dmin1 = INFINITY;
+  double dmin2 = INFINITY;
+  size_t const numel = *(ens -> numel);
+  for (size_t i = 0; i != (numel - 1); ++i)
+  {
+    const point_t* point2 = (point1 + 1);
+    for (size_t j = (i + 1); j != numel; ++j)
+    {
+      double const d = point1 -> dist(point1, point2);
+      if (d <= dmin1)
+      {
+	dmin2 = dmin1;
+	dmin1 = d;
+      }
+      ++point2;
+    }
+    ++point1;
+  }
+  bool const hasDuplicateClosestPairs = ( (dmin1 == dmin2)? true : false );
+  return hasDuplicateClosestPairs;
+}
+
+
+void initialize (ensemble_t* ens)
+{
+  do
+  {
+    generate(ens);
+  } while ( hasDuplicateClosestPairs(ens) );
+}
+
+
+void bruteForce (const ensemble_t* ens, pair_t* closestPair)
+{
+  size_t const numel = *(ens -> numel);
+  const point_t* points = ens -> points;
+
+  size_t first = numel;
+  size_t second = numel;
+  double dmin = INFINITY;
+  const point_t* point1 = points;
+  for (size_t i = 0; i != (numel - 1); ++i)
+  {
+    const point_t* point2 = (point1 + 1);
+    for (size_t j = (i + 1); j != numel; ++j)
+    {
+      double const d = point1 -> dist(point1, point2);
+      if (d < dmin)
+      {
+	first = i;
+	second = j;
+	dmin = d;
+      }
+      ++point2;
+    }
+    ++point1;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+void direct (const ensemble_t* ens, pair_t* closestPair)
+{
+  const point_t* points = ens -> points;
+  const point_t* point1 = points;
+  const point_t* point2 = points + 1;
+  double const dist = point1 -> dist(point1, point2);
+  double const dmin = closestPair -> getDistance(closestPair);
+  if (dist < dmin)
+  {
+    size_t const first = point1 -> getID(point1);
+    size_t const second = point2 -> getID(point2);
+    closestPair -> set(closestPair, first, second, dist);
+  }
+}
+
+
+void xcombine (const ensemble_t* leftEx, const ensemble_t* rightEx, pair_t* closestPair)
+{
+  size_t const numel = *(leftEx -> numel);
+  size_t const beginLeft = 0;
+  size_t const endLeft = numel;
+  size_t const beginRight = 0;
+  size_t const endRight = numel;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  double const dist = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const offset = ( numel - (i + 1) );
+    const point_t* pivot = rightEx -> points;
+    const point_t* left = leftEx -> points + offset;
+    double const d = left -> dist_x(left, pivot);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = 0; i != (endRight - beginRight); ++i)
+  {
+    size_t const offset = i;
+    size_t const last = (numel - 1);
+    const point_t* pivot = leftEx -> points + last;
+    const point_t* right = rightEx -> points + offset;
+    double const d = right -> dist_x(right, pivot);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  size_t first = closestPair -> getFirst(closestPair);
+  size_t second = closestPair -> getSecond(closestPair);
+  double dmin = closestPair -> getDistance(closestPair);
+  const point_t* left = leftEx -> points + bLeft;
+  for (size_t i = 0; i != (eLeft - bLeft); ++i)
+  {
+    const point_t* right = rightEx -> points + bRight;
+    for (size_t j = 0; j != (eRight - bRight); ++j)
+    {
+      double const d =left -> dist(left, right);
+      if (d < dmin)
+      {
+	first = left -> getID(left);
+	second = right -> getID(right);
+	dmin = d;
+      }
+      ++right;
+    }
+    ++left;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+// as xcombine() but uses the y-axis distances to determine too far elements
+void ycombine (const ensemble_t* leftEy, const ensemble_t* rightEy, pair_t* closestPair)
+{
+  size_t const numel = *(leftEy -> numel);
+  size_t const beginLeft = 0;
+  size_t const endLeft = numel;
+  size_t const beginRight = 0;
+  size_t const endRight = numel;
+
+  // prunes elements (too far to comprise the closest pair) from the left partition:
+
+  size_t bLeft = endLeft;
+  size_t const eLeft = endLeft;
+  double const dist = closestPair -> getDistance(closestPair);
+  for (size_t i = 0; i != (endLeft - beginLeft); ++i)
+  {
+    size_t const offset = ( numel - (i + 1) );
+    const point_t* pivot = rightEy -> points;
+    const point_t* left = leftEy -> points + offset;
+    double const d = left -> dist_y(left, pivot);
+    if (d < dist)
+    {
+      --bLeft;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // prunes elements (too far to comprise the closest pair) from the right partition:
+
+  size_t const bRight = beginRight;
+  size_t eRight = beginRight;
+  for (size_t i = 0; i != (endRight - beginRight); ++i)
+  {
+    size_t const offset = i;
+    size_t const last = (numel - 1);
+    const point_t* pivot = leftEy -> points + last;
+    const point_t* right = rightEy -> points + offset;
+    double const d = right -> dist_y(right, pivot);
+    if (d < dist)
+    {
+      ++eRight;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  // uses brute force on the (pruned) combined partition:
+
+  size_t first = closestPair -> getFirst(closestPair);
+  size_t second = closestPair -> getSecond(closestPair);
+  double dmin = closestPair -> getDistance(closestPair);
+  const point_t* left = leftEy -> points + bLeft;
+  for (size_t i = 0; i != (eLeft - bLeft); ++i)
+  {
+    const point_t* right = rightEy -> points + bRight;
+    for (size_t j = 0; j != (eRight - bRight); ++j)
+    {
+      double const d =left -> dist(left, right);
+      if (d < dmin)
+      {
+	first = left -> getID(left);
+	second = right -> getID(right);
+	dmin = d;
+      }
+      ++right;
+    }
+    ++left;
+  }
+  closestPair -> set(closestPair, first, second, dmin);
+}
+
+
+// partitions the ensemble in the x dimension into left and right partitions
+void xpart (const ensemble_t* Ex,
+	    const ensemble_t* Ey,
+	    ensemble_t* leftEx,
+	    ensemble_t* rightEx,
+	    ensemble_t* leftEy,
+	    ensemble_t* rightEy)
+{
+  size_t const numel = *(Ex -> numel);
+
+  const point_t* src = Ex -> points;
+  point_t* dst = leftEx -> points;
+  copy(dst, src, numel / 2);
+
+  src += (numel / 2);
+  dst = rightEx -> points;
+  copy(dst, src, numel / 2);
+
+  src = Ey -> points;
+  point_t* left = leftEy -> points;
+  point_t* right = rightEy -> points;
+  point_t* pivot = rightEx -> points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    if (point.xcomparator(src, pivot) == -1)
+    {
+      left -> clone(left, src);
+      ++left;
+    }
+    else
+    {
+      right -> clone(right, src);
+      ++right;
+    }
+    ++src;
+  }
+}
+
+
+// partitions the ensemble in the y dimension into left and right partitions
+void ypart (const ensemble_t* Ex,
+	    const ensemble_t* Ey,
+	    ensemble_t* leftEx,
+	    ensemble_t* rightEx,
+	    ensemble_t* leftEy,
+	    ensemble_t* rightEy)
+{
+  size_t const numel = *(Ey -> numel);
+
+  const point_t* src = Ey -> points;
+  point_t* dst = leftEy -> points;
+  copy(dst, src, numel / 2);
+
+  src += (numel / 2);
+  dst = rightEy -> points;
+  copy(dst, src, numel / 2);
+
+  src = Ex -> points;
+  point_t* left = leftEx -> points;
+  point_t* right = rightEx -> points;
+  point_t* pivot = rightEy -> points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    if (point.ycomparator(src, pivot) == -1)
+    {
+      left -> clone(left, src);
+      ++left;
+    }
+    else
+    {
+      right -> clone(right, src);
+      ++right;
+    }
+    ++src;
+  }
+}
+
+
+// as recurse() but partitions the system in the y dimension
+void divide (const ensemble_t* Ex, const ensemble_t* Ey, pair_t* closestPair)
+{
+  size_t const numel = *(Ey -> numel);
+  if (numel == 2)
+  {
+    direct(Ey, closestPair);
+  }
+  else
+  {
+    ensemble_t* leftEx = ensemble.create(numel / 2);
+    ensemble_t* rightEx = ensemble.create(numel / 2);
+    ensemble_t* leftEy = ensemble.create(numel / 2);
+    ensemble_t* rightEy = ensemble.create(numel / 2);
+
+    ypart(Ex, Ey, leftEx, rightEx, leftEy, rightEy);
+
+    pair_t* closestPairLeft = pair.create();
+    recurse(leftEx, leftEy, closestPairLeft);
+
+    pair_t* closestPairRight = pair.create();
+    recurse(rightEx, rightEy, closestPairRight);
+
+    closestPair -> min(closestPair, closestPairLeft, closestPairRight);
+
+    ycombine(leftEy, rightEy, closestPair);
+
+    leftEx = ensemble.destroy(leftEx);
+    rightEx = ensemble.destroy(rightEx);
+    leftEy = ensemble.destroy(leftEy);
+    rightEy = ensemble.destroy(rightEy);
+    closestPairLeft = pair.destroy(closestPairLeft);
+    closestPairRight = pair.destroy(closestPairRight);
+  }
+}
+
+
+void recurse (const ensemble_t* Ex, const ensemble_t* Ey, pair_t* closestPair)
+{
+  size_t const numel = *(Ex -> numel);
+  if (numel == 2)
+  {
+    direct(Ex, closestPair);
+  }
+  else
+  {
+    ensemble_t* leftEx = ensemble.create(numel / 2);
+    ensemble_t* rightEx = ensemble.create(numel / 2);
+    ensemble_t* leftEy = ensemble.create(numel / 2);
+    ensemble_t* rightEy = ensemble.create(numel / 2);
+
+    xpart(Ex, Ey, leftEx, rightEx, leftEy, rightEy);
+
+    pair_t* closestPairLeft = pair.create();
+    divide(leftEx, leftEy, closestPairLeft);
+
+    pair_t* closestPairRight = pair.create();
+    divide(rightEx, rightEy, closestPairRight);
+
+    closestPair -> min(closestPair, closestPairLeft, closestPairRight);
+
+    xcombine(leftEx, rightEx, closestPair);
+
+    leftEx = ensemble.destroy(leftEx);
+    rightEx = ensemble.destroy(rightEx);
+    leftEy = ensemble.destroy(leftEy);
+    rightEy = ensemble.destroy(rightEy);
+    closestPairLeft = pair.destroy(closestPairLeft);
+    closestPairRight = pair.destroy(closestPairRight);
+  }
+}
+
+
+// defines an interface to the Divide-And-Conquer algorithm that finds the closest pair
+void divideAndConquer (const ensemble_t* ens, pair_t* closestPair)
+{
+  size_t const numel = *(ens -> numel);
+
+  ensemble_t* Ex = ensemble.create(numel);
+  Ex -> clone(Ex, ens);
+  sort(Ex, 0, numel, point.xcomparator);
+
+  ensemble_t* Ey = ensemble.create(numel);
+  Ey -> clone(Ey, ens);
+  sort(Ey, 0, numel, point.ycomparator);
+
+  recurse(Ex, Ey, closestPair);
+
+  Ex = ensemble.destroy(Ex);
+  Ey = ensemble.destroy(Ey);
+}
+
+
+void test_bruteForce ()
+{
+  pair_t* closestPair = pair.create();
+  if (closestPair == NULL)
+  {
+    return;
+  }
+
+  size_t const numel = iNUMEL;
+  ensemble_t* ens = ensemble.create(numel);
+  initialize(ens);
+
+  const point_t* points = ens -> points;
+  const point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> log(point);
+    ++point;
+  }
+
+  bruteForce(ens, closestPair);
+  printf("bruteForce(): ");
+  closestPair -> log(closestPair);
+
+  ens = ensemble.destroy(ens);
+  closestPair = pair.destroy(closestPair);
+}
+
+
+// tests the implementation with problem 2.3.1-1 of reference [1]
+void test_recurse ()
+{
+  // note that we have added four more elements to meet create()'s requirements
+  double x[] = {2,  4, 5, 10, 13, 15, 17, 19, 22, 25, 29, 30, 64, -64, -64,  64};
+  double y[] = {7, 13, 7,  5,  9,  5,  7, 10,  7, 10, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = pair.create();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = pair.create();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ens = ensemble.create(numel);
+  point_t* points = ens -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ens, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  divideAndConquer(ens, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[0]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ens = ensemble.destroy(ens);
+  closestPairBruteForce = pair.destroy(closestPairBruteForce);
+  closestPairRecurse = pair.destroy(closestPairRecurse);
+}
+
+
+// tests the implementation with problem 2.3.1-2 of reference [1]
+void test_recurse1 ()
+{
+  double x[] = {1,  1, 7, 9, 12, 13, 20, 22, 23, 25, 26, 31, 64, -64, -64,  64};
+  double y[] = {2, 11, 8, 9, 13,  4,  8,  3, 12, 14,  7, 10, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = pair.create();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = pair.create();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ens = ensemble.create(numel);
+  point_t* points = ens -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ens, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  divideAndConquer(ens, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[1]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ens = ensemble.destroy(ens);
+  closestPairBruteForce = pair.destroy(closestPairBruteForce);
+  closestPairRecurse = pair.destroy(closestPairRecurse);
+}
+
+
+// tests the implementation with problem 2.3.1-3 of reference [1]
+void test_recurse2 ()
+{
+  double x[] = {2,  2, 5,  9, 11, 15, 17, 18, 22, 25, 28, 30, 64, -64, -64,  64};
+  double y[] = {2, 12, 4, 11,  4, 14, 13,  7,  4,  7, 14,  2, 64,  64, -64, -64};
+  size_t const numel = ( sizeof(x) / sizeof(double) );
+
+  pair_t* closestPairBruteForce = pair.create();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = pair.create();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    return;
+  }
+
+  ensemble_t* ens = ensemble.create(numel);
+  point_t* points = ens -> points;
+  point_t* point = points;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    point -> set(point, x[i], y[i], i);
+    ++point;
+  }
+
+  closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+  bruteForce(ens, closestPairBruteForce);
+
+  closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+  divideAndConquer(ens, closestPairRecurse);
+
+  bool failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+  printf("test-recurse[2]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  ens = ensemble.destroy(ens);
+  closestPairBruteForce = pair.destroy(closestPairBruteForce);
+  closestPairRecurse = pair.destroy(closestPairRecurse);
+}
+
+
+void test_recurse3 ()
+{
+  pair_t* closestPairBruteForce = pair.create();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = pair.create();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    return;
+  }
+
+  bool failed = false;
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    ensemble_t* ens = ensemble.create(numel);
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ens);
+
+      closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+      bruteForce(ens, closestPairBruteForce);
+
+      closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+      divideAndConquer(ens, closestPairRecurse);
+
+      failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+      if (failed)
+      {
+	printf("bruteForce(): ");
+	closestPairBruteForce -> log(closestPairBruteForce);
+	printf("recurse(): ");
+	closestPairRecurse -> log(closestPairRecurse);
+	break;
+      }
+    }
+
+    if (failed)
+    {
+      ens = ensemble.destroy(ens);
+      break;
+    }
+
+    ens = ensemble.destroy(ens);
+    numel *= 2;
+  }
+
+  printf("test-recurse[3]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  closestPairBruteForce = pair.destroy(closestPairBruteForce);
+  closestPairRecurse = pair.destroy(closestPairRecurse);
+}
+
+
+void test_sort ()
+{
+  bool failed = false;
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    ensemble_t* ens = ensemble.create(numel);
+
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ens);
+
+      sort(ens, 0, numel, point.xcomparator);
+
+      failed = !sorted(ens, 0, numel, point.xcomparator);
+      if (failed)
+      {
+	break;
+      }
+    }
+
+    if (failed)
+    {
+      ens = ensemble.destroy(ens);
+      break;
+    }
+
+    ens = ensemble.destroy(ens);
+    numel *= 2;
+  }
+
+  printf("test-sort[0]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+}
+
+
+void complexity_sort ()
+{
+  bool failed = false;
+  double etimes[RUNS];
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    ensemble_t* ens = ensemble.create(numel);
+
+    double etime = 0;
+    struct timespec end;
+    struct timespec begin;
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ens);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &begin);
+
+      sort(ens, 0, numel, point.xcomparator);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+      etime += getElapsedTime(&begin, &end);
+
+      failed = !sorted(ens, 0, numel, point.xcomparator);
+      if (failed)
+      {
+	break;
+      }
+    }
+
+    etimes[run] = etime / ( (double) REPS );
+
+    if (failed)
+    {
+      ens = ensemble.destroy(ens);
+      break;
+    }
+
+    ens = ensemble.destroy(ens);
+    numel *= 2;
+  }
+
+  printf("test-sort[1]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  if (failed)
+  {
+    return;
+  }
+
+  const char fname[] = "complexity-sort.txt";
+  FILE* file = fopen(fname, "w");
+
+  if (file == NULL)
+  {
+    printf("complexity-sort(): IO ERROR with file %s\n", fname);
+    return;
+  }
+
+  numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    fprintf(file, "%lu %.16e\n", numel, etimes[run]);
+    numel *= 2;
+  }
+
+  fclose(file);
+  printf("complexity-sort(): time complexity results have been writen to %s\n", fname);
+}
+
+
+void complexity_recurse ()
+{
+  pair_t* closestPairBruteForce = pair.create();
+  if (closestPairBruteForce == NULL)
+  {
+    return;
+  }
+
+  pair_t* closestPairRecurse = pair.create();
+  if (closestPairRecurse == NULL)
+  {
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    return;
+  }
+
+  bool failed = false;
+  double etimes[RUNS];
+  size_t numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    double etime = 0;
+    struct timespec end;
+    struct timespec begin;
+    ensemble_t* ens = ensemble.create(numel);
+    for (size_t rep = 0; rep != REPS; ++rep)
+    {
+      initialize(ens);
+
+      closestPairBruteForce -> set(closestPairBruteForce, numel, numel, INFINITY);
+      bruteForce(ens, closestPairBruteForce);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &begin);
+
+      closestPairRecurse -> set(closestPairRecurse, numel, numel, INFINITY);
+      divideAndConquer(ens, closestPairRecurse);
+
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+      etime += getElapsedTime(&begin, &end);
+
+      failed = !closestPairRecurse -> cmp(closestPairRecurse, closestPairBruteForce);
+      if (failed)
+      {
+	printf("bruteForce(): ");
+	closestPairBruteForce -> log(closestPairBruteForce);
+	printf("recurse(): ");
+	closestPairRecurse -> log(closestPairRecurse);
+	break;
+      }
+    }
+
+    etimes[run] = etime / ( (double) REPS );
+
+    if (failed)
+    {
+      ens = ensemble.destroy(ens);
+      break;
+    }
+
+    ens = ensemble.destroy(ens);
+    numel *= 2;
+  }
+
+  printf("test-recurse[4]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  const char fname[] = "complexity-recurse.txt";
+  FILE* file = fopen(fname, "w");
+  if (file == NULL)
+  {
+    closestPairRecurse = pair.destroy(closestPairRecurse);
+    closestPairBruteForce = pair.destroy(closestPairBruteForce);
+    printf("complexity-recurse(): IO ERROR with file %s\n", fname);
+    return;
+  }
+
+  numel = iNUMEL;
+  for (size_t run = 0; run != RUNS; ++run)
+  {
+    fprintf(file, "%lu %.16e\n", numel, etimes[run]);
+    numel *= 2;
+  }
+
+  fclose(file);
+  closestPairRecurse = pair.destroy(closestPairRecurse);
+  closestPairBruteForce = pair.destroy(closestPairBruteForce);
+  printf("complexity-recurse(): time complexity results have been writen to %s\n", fname);
+}
+
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: test.c
+author: @misael-diaz
+
+Synopsis:
+Solves the 2D closest pair problem.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/util.c
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/util.c
@@ -1,0 +1,195 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+#include "util.h"
+
+
+double getElapsedTime (const struct timespec* b, const struct timespec* e)
+{
+  double begin = ( (double) (b -> tv_nsec) ) + 1.0e9 * ( (double) (b -> tv_sec) );
+  double end   = ( (double) (e -> tv_nsec) ) + 1.0e9 * ( (double) (e -> tv_sec) );
+  return (end - begin);
+}
+
+
+double urand (double const size)
+{
+  double const lim = (size * size);
+  double const min = -lim;
+  double const max = +lim;
+  double const urand = ( (double) rand() ) / ( (double) RAND_MAX );
+  double const r = min + urand * (max - min);
+  return round(r);
+}
+
+
+int search (const point_t* points, size_t const b, size_t const e, const point_t* target)
+{
+  const point_t* pnt = points;
+  extern point_namespace_t const point;
+  for (size_t i = b; i != e; ++i)
+  {
+    if (point.xcomparator(pnt, target) == 0)
+    {
+      return i;
+    }
+    ++pnt;
+  }
+  return -1;
+}
+
+
+void copy (point_t* dst, const point_t* src, size_t const numel)
+{
+  point_t* idst = dst;
+  const point_t* isrc = src;
+  for (size_t i = 0; i != numel; ++i)
+  {
+    idst -> clone(idst, isrc);
+    ++idst;
+    ++isrc;
+  }
+}
+
+
+bool sorted (const ensemble_t* ensemble, size_t const beg, size_t const end,
+	    int (*comp) (const point_t* point1, const point_t* point2))
+{
+  bool sorted = true;
+  const point_t* points = ensemble -> points;
+  const point_t* point = points;
+  for (size_t i = beg; i != (end - 1); ++i)
+  {
+    const point_t* pnt1 = point;
+    const point_t* pnt2 = (point + 1);
+    if (comp(pnt2, pnt1) == -1)
+    {
+      sorted = false;
+      return sorted;
+    }
+    ++point;
+  }
+  return sorted;
+}
+
+
+static void direct (ensemble_t* ensemble, size_t const beg, size_t const end,
+		    int (*comp) (const point_t* point1, const point_t* point2))
+{
+  size_t const offset = beg;
+  point_t* point1 = ensemble -> points + offset;
+  point_t* point2 = ensemble -> points + (offset + 1);
+
+  point_t* smallerPoint = ensemble -> temp;
+  if (comp(point2, point1) == -1)
+  {
+    smallerPoint -> clone(smallerPoint, point2);
+    point2 -> clone(point2, point1);
+    point1 -> clone(point1, smallerPoint);
+  }
+}
+
+
+static void combine(ensemble_t* ensemble, size_t const beg, size_t const end,
+		    int (*comp) (const point_t* point1, const point_t* point2))
+{
+  size_t const beginLeft = beg;
+  size_t const endLeft = beg + ( (end - beg) / 2 );
+  size_t const beginRight = beg + ( (end - beg) / 2 );
+  size_t const endRight = end;
+
+  size_t iterLeft = beginLeft;
+  size_t iterRight = beginRight;
+  point_t* points = ensemble -> points;
+  point_t* dst = ensemble -> temp;
+  while ( (iterLeft != endLeft) && (iterRight != endRight) )
+  {
+    point_t* pointLeft = points + iterLeft;
+    point_t* pointRight = points + iterRight;
+    if (comp(pointLeft, pointRight) == -1)
+    {
+      point_t* smallerPoint = pointLeft;
+      dst -> clone(dst, smallerPoint);
+      ++iterLeft;
+    }
+    else
+    {
+      point_t* smallerPoint = pointRight;
+      dst -> clone(dst, smallerPoint);
+      ++iterRight;
+    }
+    ++dst;
+  }
+
+  size_t b = iterLeft;
+  size_t e = endLeft;
+  const point_t* src = (points + b);
+  copy(dst, src, e - b);
+
+  dst += (e - b);
+
+  b = iterRight;
+  e = endRight;
+  src = (points + b);
+  copy(dst, src, e - b);
+
+  dst = (points + beg);
+  src = ensemble -> temp;
+  copy(dst, src, end - beg);
+}
+
+
+void sort(ensemble_t* ensemble, size_t const beg, size_t const end,
+	  int (*comp) (const point_t* point1, const point_t* point2))
+{
+  size_t const numel = (end - beg);
+  for (size_t i = 0; i != numel; i += 2)
+  {
+    size_t const offset = beg;
+    size_t const b = (i + offset);
+    size_t const e = ( (i + 1) + offset);
+    direct(ensemble, b, e, comp);
+  }
+
+  if (numel == 2)
+  {
+    return;
+  }
+
+  for (size_t stride = 4; stride != numel; stride *= 2)
+  {
+    for (size_t i = 0; i != numel; i += stride)
+    {
+      size_t const offset = beg;
+      size_t const b = (i + offset);
+      size_t const e = ( (i + stride) + offset );
+      combine(ensemble, b, e, comp);
+    }
+  }
+
+  combine(ensemble, beg, end, comp);
+}
+
+
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: util.c
+author: @misael-diaz
+
+Synopsis:
+Defines utilities to solve the closest pair problem.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/

--- a/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/util.h
+++ b/src/algorithms/divide-and-conquer/closest-pair/clang/opt-oop-closest-pair/clang/util.h
@@ -1,0 +1,37 @@
+#ifndef GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
+#define GUARD_AC_CLOSEST_PAIR_OOP_UTIL_H
+
+#include <time.h>
+#include "ensemble.h"
+#include "pair.h"
+
+double getElapsedTime (const struct timespec* b, const struct timespec* e);
+int search(const point_t* points, size_t const b, size_t const e, const point_t* target);
+double urand(double const size);
+void copy (point_t* dst, const point_t* src, size_t const numel);
+bool sorted(const ensemble_t* ensemble, size_t const b, size_t const e,
+	    int (*comp) (const point_t* p, const point_t* q));
+void sort(ensemble_t* ensemble, size_t const b, size_t const e,
+	  int (*comp) (const point_t* p, const point_t* q));
+
+#endif
+/*
+
+Algorithms and Complexity					August 24, 2023
+
+source: util.h
+author: @misael-diaz
+
+Synopsis:
+Header for the closest pair utilities.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] JJ McConnell, Analysis of Algorithms, second edition.
+
+*/


### PR DESCRIPTION
COMMENTS:
Adds optimal implementation (in terms of number of operations) of the Divide And Conquer algorithm that finds the closest pair.

This implementation partitions the points in O(N) operations at the expense of allocating the partitions on the heap; despite of these allocations the space complexity is O(N).

The expected theoretical overall time complexity is O(N log N).

code passes all tests

valgrind reports no memory issues

closes #211 